### PR TITLE
Fix: setReadOnly(false) was having no effect

### DIFF
--- a/js/visual/Slider.js
+++ b/js/visual/Slider.js
@@ -274,6 +274,8 @@ export class Slider extends util.mix(VisualStim).with(ColorMixin)
 			// halve the opacity:
 			if (readOnly)
 				this._opacity /= 2.0;
+			else
+				this._opacity *= 2.0;
 
 			this._needUpdate = true;
 		}


### PR DESCRIPTION
As noted in this discourse post:
https://discourse.psychopy.org/t/slider-setreadonly-sets-contrast-incorrectly/7055

Also, I wonder if we should be changing contrast by halving the color
values (if they are signed color vals) rather than the transparency, in
keeping with the Python version. Transparency will be weird if the scale
is on a textured backgorund?