### PR TITLE
ENH: adds .editorconfig file to repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# top-most EditorConfig file
+root = true
+
+# Don't use tabs for indentation.
+[*]
+indent_style = space
+# (Please don't specify an indent_size here; that has too many unintended consequences.)
+
+# Python files
+[*.{py}]
+indent_style = tab
+indent_size = 4
+
+# HTML+CSS/JS  files
+[*.{html,css,js}]
+indent_style = tab
+indent_size = 2


### PR DESCRIPTION
The indentation in JS and HTML looks wrong because of GitHubs default
settings (I think is 8 spaces for an indent?). This .editorconfig file
allows us to define what indentation params should be used for specific
file types, making the JS more readable and consistent with code style
convention.