### PR TITLE
BF: Keep filenames in conditions file as string if starting with number

### DIFF
--- a/js/data/TrialHandler.js
+++ b/js/data/TrialHandler.js
@@ -315,7 +315,7 @@ export class TrialHandler extends PsychObject {
 						let value = row[l];
 
 						// if value is a numerical string, convert it to a number:
-						if (typeof value === 'string') {
+						if (typeof value === 'string' && !/[a-zA-Z]/.test(value)) {
 							const numericalValue = Number.parseFloat(value);
 							if (!Number.isNaN(numericalValue))
 								value = numericalValue;


### PR DESCRIPTION
Users report issues where filenames from conditions files are not found because they begin with a number. This is because importConditions parses strings as numbers if they can be converted successfully . E.g., `01.jpg` becomes `1`.  This fix tests if a value also contains a character, and if so, does not convert string to number.