### PR TITLE
BF: Multiple fixes, mostly re GUI dlg; fixes #52

### DIFF
--- a/js/core/GUI.js
+++ b/js/core/GUI.js
@@ -255,6 +255,7 @@ export class GUI
 					// close is called by both buttons and when the user clicks on the cross:
 					close: function () {
 						//$.unblockUI();
+						$(this).dialog('destroy').remove();
 						self._dialogComponent.status = PsychoJS.Status.FINISHED;
 					}
 
@@ -313,8 +314,6 @@ export class GUI
 		showOK = true,
 		onOK
 	} = {}) {
-		// destroy previous dialog box:
-		this.destroyDialog();
 
 		let htmlCode;
 		let titleColour;
@@ -410,7 +409,7 @@ export class GUI
 				id: "buttonOk",
 				text: "Ok",
 				click: function() {
-					$(this).dialog("close");
+					$(this).dialog("destroy").remove();
 
 					// execute callback function:
 					if (typeof onOK !== 'undefined')
@@ -501,24 +500,6 @@ export class GUI
 				top: Math.max(0, (windowSize[1] - parent.outerHeight()) / 2.0),
 			});
 		} );
-	}
-
-
-	/**
-	 * Destroy the currently opened dialog box.
-	 *
-	 * @name module:core.GUI#dialog
-	 * @function
-	 * @public
-	 */
-	destroyDialog()
-	{
-		if ($("#expDialog").length) {
-			$("#expDialog").dialog("destroy");
-		}
-		if ($("#msgDialog").length) {
-			$("#msgDialog").dialog("destroy");
-		}
 	}
 
 

--- a/js/core/GUI.js
+++ b/js/core/GUI.js
@@ -79,7 +79,7 @@ export class GUI
 		this._progressBarMax = 0;
 		this._allResourcesDownloaded = false;
 		this._requiredKeys = [];
-		this._nbSetRequiredKeys = 0;
+		this._setRequiredKeys = new Map();
 
 
 		// prepare PsychoJS component:
@@ -581,7 +581,7 @@ export class GUI
 	 */
 	_updateOkButtonStatus()
 	{
-		if (this._psychoJS.getEnvironment() === ExperimentHandler.Environment.LOCAL || (this._allResourcesDownloaded && this._nbSetRequiredKeys >= this._requiredKeys.length) )
+		if (this._psychoJS.getEnvironment() === ExperimentHandler.Environment.LOCAL || (this._allResourcesDownloaded && this._setRequiredKeys.size >= this._requiredKeys.length) )
 		{
 			$("#buttonOk").button("option", "disabled", false);
 		} else
@@ -656,9 +656,9 @@ export class GUI
 		const value = element.value;
 
 		if (typeof value !== 'undefined' && value.length > 0)
-			gui._nbSetRequiredKeys++;
+			gui._setRequiredKeys.set(event.target, true);
 		else
-			gui._nbSetRequiredKeys--;
+			gui._setRequiredKeys.delete(event.target);
 
 		gui._updateOkButtonStatus();
 	}

--- a/js/core/GUI.js
+++ b/js/core/GUI.js
@@ -130,7 +130,7 @@ export class GUI
 				htmlCode += '<form>';
 				for (const key in dictionary) {
 					const value = dictionary[key];
-					const keyId = key + '_id';
+					const keyId = $.escapeSelector(key) + '_id';
 
 					// only create an input if the key is not in the URL:
 					let inUrl = false;
@@ -200,7 +200,7 @@ export class GUI
 
 				// setup change event handlers for all required keys:
 				for (const key of this._requiredKeys) {
-					const keyId = key + '_id';
+					const keyId = $.escapeSelector(key) + '_id';
 					const input = document.getElementById(keyId);
 					if (input)
 						input.onchange = (event) => GUI._onKeyChange(self, event);
@@ -227,7 +227,7 @@ export class GUI
 
 								// update dictionary:
 								for (const key in dictionary) {
-									const input = document.getElementById(key + "_id");
+									const input = document.getElementById($.escapeSelector(key) + "_id");
 									if (input)
 										dictionary[key] = input.value;
 								}

--- a/js/core/GUI.js
+++ b/js/core/GUI.js
@@ -19,7 +19,7 @@ import * as util from '../util/Util';
 /**
  * @class
  * Graphic User Interface
- * 
+ *
  * @name module:core.GUI
  * @class
  * @param {module:core.PsychoJS} psychoJS the PsychoJS instance
@@ -46,7 +46,7 @@ export class GUI
 	 * <p>Create a dialog box that (a) enables the participant to set some
 	 * experimental values (e.g. the session name), (b) shows progress of resource
 	 * download, and (c) enables the participant to cancel the experiment.</p>
-	 * 
+	 *
 	 * <b>Setting experiment values</b>
 	 * <p>DlgFromDict displays an input field for all values in the dictionary.
 	 * It is possible to specify default values e.g.:</p>
@@ -55,7 +55,7 @@ export class GUI
 	 * psychoJS.schedule(psychoJS.gui.DlgFromDict({dictionary: expInfo, title: expName}));</code>
 	 * <p>If the participant cancels (by pressing Cancel or by closing the dialog box), then
 	 * the dictionary remains unchanged.</p>
-	 * 
+	 *
 	 * @name module:core.GUI#DlgFromDict
 	 * @function
 	 * @public
@@ -146,7 +146,7 @@ export class GUI
 
 					if (!inUrl)
 					{
-						htmlCode += '<label for="' + key + '">' + key + '</label>';
+						htmlCode += '<label for="' + keyId + '">' + key + '</label>';
 
 						// if the field is required:
 						if (key.slice(-1) === '*')
@@ -293,9 +293,9 @@ export class GUI
 	 */
 	/**
 	 * Show a message to the participant in a dialog box.
-	 * 
+	 *
 	 * <p>This function can be used to display both warning and error messages.</p>
-	 * 
+	 *
 	 * @name module:core.GUI#dialog
 	 * @function
 	 * @public
@@ -348,7 +348,7 @@ export class GUI
 				{
 					stackCode += '<li><b>' + error  + '</b></li>';
 					break;
-				}		
+				}
 			}
 			stackCode += '</ul>';
 
@@ -391,7 +391,7 @@ export class GUI
 		// replace root by the html code:
 		const dialogElement = document.getElementById('root');
 		dialogElement.innerHTML = htmlCode;
-		
+
 		// init and open the dialog box:
 		this._estimateDialogScalingFactor();
 		const dialogSize = this._getDialogSize();
@@ -506,7 +506,7 @@ export class GUI
 
 	/**
 	 * Destroy the currently opened dialog box.
-	 * 
+	 *
 	 * @name module:core.GUI#dialog
 	 * @function
 	 * @public

--- a/js/core/GUI.js
+++ b/js/core/GUI.js
@@ -203,7 +203,7 @@ export class GUI
 					const keyId = $.escapeSelector(key) + '_id';
 					const input = document.getElementById(keyId);
 					if (input)
-						input.onchange = (event) => GUI._onKeyChange(self, event);
+						input.oninput = (event) => GUI._onKeyChange(self, event);
 				}
 
 				// init and open the dialog box:

--- a/js/core/PsychoJS.js
+++ b/js/core/PsychoJS.js
@@ -23,7 +23,7 @@ import * as util from '../util/Util';
 
 /**
  * <p>PsychoJS manages the lifecycle of an experiment. It initialises the PsychoJS library and its various components (e.g. the {@link ServerManager}, the {@link EventManager}), and is used by the experiment to schedule the various tasks.</p>
- * 
+ *
  * @class
  * @param {Object} options
  * @param {boolean} [options.debug= true] whether or not to log debug information in the browser console
@@ -125,10 +125,10 @@ export class PsychoJS
 
 	/**
 	 * Open a PsychoJS Window.
-	 * 
+	 *
 	 * <p>This opens a PIXI canvas.</p>
 	 * <p>Note: we can only open one window.</p>
-	 * 
+	 *
 	 * @param {Object} options
 	 * @param {string} [options.name] the name of the window
 	 * @param {boolean} [options.fullscr] whether or not to go fullscreen
@@ -138,7 +138,7 @@ export class PsychoJS
 	 * @param {boolean} [options.waitBlanking] whether or not to wait for all rendering operations to be done
 	 * before flipping
 	 * @throws {Object.<string, *>} exception if a window has already been opened
-	 * 
+	 *
 	 * @public
 	 */
 	openWindow({
@@ -168,7 +168,7 @@ export class PsychoJS
 
 	/**
 	 * Set the completion and cancellation URL to which the participant will be redirect at the end of the experiment.
-	 * 
+	 *
 	 * @param {string} completionUrl  - the completion URL
 	 * @param {string} cancellationUrl - the cancellation URL
 	 */
@@ -180,7 +180,7 @@ export class PsychoJS
 
 	/**
 	 * Schedule a task.
-	 * 
+	 *
 	 * @param task - the task to be scheduled
 	 * @param args - arguments for that task
 	 * @public
@@ -198,8 +198,8 @@ export class PsychoJS
 	 */
 	/**
 	 * Schedule a series of task based on a condition.
-	 * 
-	 * @param {PsychoJS.condition} condition 
+	 *
+	 * @param {PsychoJS.condition} condition
 	 * @param {Scheduler} thenScheduler scheduler to run if the condition is true
 	 * @param {Scheduler} elseScheduler scheduler to run if the condition is false
 	 * @public
@@ -213,7 +213,7 @@ export class PsychoJS
 
 	/**
 	 * Start the experiment.
-	 * 
+	 *
 	 * @param {Object} options
 	 * @param {string} [options.configURL=config.json] - the URL of the configuration file
 	 * @param {string} [options.expName=UNKNOWN] - the name of the experiment
@@ -324,7 +324,7 @@ export class PsychoJS
 	/**
 	 * Make the attributes of the given object those of PsychoJS and those of
 	 * the top level variable (e.g. window) as well.
-	 * 
+	 *
 	 * @param {Object.<string, *>} obj the object whose attributes we will mirror
 	 * @public
 	 */
@@ -344,10 +344,10 @@ export class PsychoJS
 	/**
 	 * Close everything and exit nicely at the end of the experiment,
 	 * potentially redirecting to one of the URLs previously specified by setRedirectUrls.
-	 * 
+	 *
 	 * <p>Note: if the resource manager is busy, we inform the participant
 	 * that he or she needs to wait for a bit.</p>
-	 * 
+	 *
 	 * @param {Object} options
 	 * @param {string} [options.message] - optional message to be displayed in a dialog box before quitting
 	 * @param {boolean} [options.isCompleted = false] - whether or not the participant has completed the experiment
@@ -387,9 +387,6 @@ export class PsychoJS
 					// close the window:
 					self._window.close();
 
-					// destroy dialog boxes:
-					self._gui.destroyDialog();
-
 					// remove everything from the browser window:
 					while (document.body.hasChildNodes())
 						document.body.removeChild(document.body.lastChild);
@@ -415,7 +412,7 @@ export class PsychoJS
 
 	/**
 	 * Configure PsychoJS for the running experiment.
-	 * 
+	 *
 	 * @async
 	 * @protected
 	 * @param {string} configURL - the URL of the configuration file
@@ -515,7 +512,7 @@ export class PsychoJS
 
 	/**
 	 * Capture all errors and display them in a pop-up error box.
-	 * 
+	 *
 	 * @protected
 	 */
 	_captureErrors() {
@@ -553,7 +550,7 @@ export class PsychoJS
 
 /**
  * PsychoJS status.
- * 
+ *
  * @enum {Symbol}
  * @readonly
  * @public

--- a/js/core/Window.js
+++ b/js/core/Window.js
@@ -1,6 +1,6 @@
 /**
  * Window responsible for displaying the experiment stimuli
- * 
+ *
  * @author Alain Pitiot
  * @version 2020.1
  * @copyright (c) 2020 Ilixa Ltd. ({@link http://ilixa.com})
@@ -15,7 +15,7 @@ import { Logger } from "./Logger";
 /**
  * <p>Window displays the various stimuli of the experiment.</p>
  * <p>It sets up a [PIXI]{@link http://www.pixijs.com/} renderer, which we use to render the experiment stimuli.</p>
- * 
+ *
  * @name module:core.Window
  * @class
  * @extends PsychObject
@@ -33,7 +33,7 @@ export class Window extends PsychObject {
 
 	/**
 	 * Getter for monitorFramePeriod.
-	 * 
+	 *
 	 * @name module:core.Window#monitorFramePeriod
 	 * @function
 	 * @public
@@ -95,9 +95,9 @@ export class Window extends PsychObject {
 
 	/**
 	 * Close the window.
-	 * 
+	 *
 	 * <p> Note: this actually only removes the canvas used to render the experiment stimuli.</p>
-	 * 
+	 *
 	 * @name module:core.Window#close
 	 * @function
 	 * @public
@@ -121,7 +121,7 @@ export class Window extends PsychObject {
 		{
 			this._renderer.destroy();
 		}
-			
+
 		window.removeEventListener('resize', this._resizeCallback);
 		window.removeEventListener('orientationchange', this._resizeCallback);
 
@@ -131,12 +131,12 @@ export class Window extends PsychObject {
 
 	/**
 	 * Estimate the frame rate.
-	 * 
+	 *
 	 * @name module:core.Window#getActualFrameRate
 	 * @function
 	 * @public
 	 * @return {number} always returns 60.0 at the moment
-	 * 
+	 *
 	 * @todo estimate the actual frame rate.
 	 */
 	getActualFrameRate()
@@ -148,7 +148,7 @@ export class Window extends PsychObject {
 
 	/**
 	 * Take the browser full screen if possible.
-	 * 
+	 *
 	 * @name module:core.Window#adjustScreenSize
 	 * @function
 	 * @public
@@ -227,9 +227,9 @@ export class Window extends PsychObject {
 
 	/**
 	 * Log a message.
-	 * 
+	 *
 	 * <p> Note: the message will be time-stamped at the next call to requestAnimationFrame.</p>
-	 * 
+	 *
 	 * @name module:core.Window#logOnFlip
 	 * @function
 	 * @public
@@ -256,9 +256,9 @@ export class Window extends PsychObject {
 	/**
 	 * Add a callback function that will run after the next screen flip, i.e. immediately after the next rendering of the
 	 * Window.
-	 * 
+	 *
 	 * <p>This is typically used to reset a timer or clock.</p>
-	 * 
+	 *
 	 * @name module:core.Window#callOnFlip
 	 * @function
 	 * @public
@@ -273,7 +273,7 @@ export class Window extends PsychObject {
 
 	/**
 	 * Render the stimuli onto the canvas.
-	 * 
+	 *
 	 * @name module:core.Window#render
 	 * @function
 	 * @public
@@ -315,7 +315,7 @@ export class Window extends PsychObject {
 
 	/**
 	 * Update this window, if need be.
-	 * 
+	 *
 	 * @name module:core.Window#_updateIfNeeded
 	 * @function
 	 * @private
@@ -337,7 +337,7 @@ export class Window extends PsychObject {
 
 	/**
 	 * Recompute this window's draw list and _container children for the next animation frame.
-	 * 
+	 *
 	 * @name module:core.Window#_refresh
 	 * @function
 	 * @private
@@ -376,10 +376,10 @@ export class Window extends PsychObject {
 
 	/**
 	 * Setup PIXI.
-	 * 
+	 *
 	 * <p>A new renderer is created and a container is added to it. The renderer's touch and mouse events
 	 * are handled by the {@link EventManager}.</p>
-	 * 
+	 *
 	 * @name module:core.Window#_setupPixi
 	 * @function
 	 * @private
@@ -392,7 +392,8 @@ export class Window extends PsychObject {
 
 		// create a PIXI renderer and add it to the document:
 		this._renderer = PIXI.autoDetectRenderer(this._size[0], this._size[1], {
-			backgroundColor: this.color.int
+			backgroundColor: this.color.int,
+			resolution: window.devicePixelRatio,
 		});
 		this._renderer.view.style.transform = 'translatez(0)';
 		this._renderer.view.style.position = 'absolute';
@@ -456,7 +457,7 @@ export class Window extends PsychObject {
 
 	/**
 	 * Send all logged messages to the {@link Logger}.
-	 * 
+	 *
 	 * @name module:core.Window#_writeLogOnFlip
 	 * @function
 	 * @private


### PR DESCRIPTION
- Fix Window._setupPixi: use `resolution: window.devicePixelRatio` to prevent blurriness on HiDPI displays
- Multiple GUI.DlgFromDict fixes:
- - use `$.escapeSelector()` to prevent special characters in questions causing problems in element IDs (Fixes psychopy/psychojs#52)
- - label elements now properly select the corresponding input element (use `keyId`, not `key`)
- - use `.oninput` to detect input change to remove need to unselect the input element before clicking OK button
- GUI._onKeyChange now properly handles dropdown boxes (previously `_nbSetRequiredKeys++` increments continuously just by toggling dropdown options or focussing/unfocussing input elements):
- - GUI._onKeyChange: use `gui._setRequiredKeys.set(event.target, true);` and `gui._setRequiredKeys.delete(event.target);`
- - GUI.DlgFromDict: use `this._setRequiredKeys = new Map()`
- - GUI._updateOkButtonStatus: use `this._setRequiredKeys.size` in conditional check
- ServerManager.downloadResources, ._downloadRegisteredResources: only process and download new resources, ignore existing resources
- Dialogs are now properly destroyed and removed from DOM when closed (previously destroyed but not removed causing duplicate element IDs, jQuery sometimes recreates old dialogs, so GUI._updateOkButtonStatus updates the wrong button):
- - Remove unnecessary GUI.destroyDialog
- - GUI.dialog: remove `this.destroyDialog();` and change `$(this).dialog("close");` to `$(this).dialog("destroy").remove();`
- - GUI.DlgFromDict: add `$(this).dialog("destroy").remove()` to `close: ...` property of `$('#expDialog').dialog`
- - PsychoJS.quit: remove unnecessary `self._gui.destroyDialog();`