### PR TITLE
visual/Slider: override refresh method a-la ShapeStim

### DIFF
--- a/js/visual/Slider.js
+++ b/js/visual/Slider.js
@@ -118,6 +118,20 @@ export class Slider extends util.mix(VisualStim).with(ColorMixin)
 
 
 	/**
+	 * Force a refresh of the stimulus.
+	 *
+	 * @name module:visual.Slider#refresh
+	 * @public
+	 */
+	refresh()
+	{
+		super.refresh();
+
+		this._needVertexUpdate = true;
+	}
+
+
+	/**
 	 * Determine whether an object is inside the bounding box of the slider.
 	 *
 	 * @name module:visual.Slider#contains


### PR DESCRIPTION
@apitiot @peircej Insert a `refresh()` method into the `Slider` component to switch on the `_needVertexUpdate` property so that resizing the `Window` properly reflects on instance position.

Issue #53 preview:
https://pavlovia.org/run/dvbridges/sliderradio/html/

With fix applied:
http://synonymous-balloon.surge.sh

Issue #83 preview:
https://run.pavlovia.org/dvbridges/test_slider/html/

With fix applied:
http://silky-friend.surge.sh
