### PR TITLE
visual/VisualStim: flip rotations to reflect psychopy convention

### DIFF
--- a/js/visual/VisualStim.js
+++ b/js/visual/VisualStim.js
@@ -101,9 +101,9 @@ export class VisualStim extends util.mix(MinimalStim).with(WindowMixin)
 	 */
 	setOri(ori, log = false)
 	{
-		this._setAttribute('ori', ori, log);
+		this._setAttribute('ori', -ori, log);
 
-		let radians = ori * 0.017453292519943295;
+		let radians = -ori * 0.017453292519943295;
 		this._rotationMatrix = [[Math.cos(radians), -Math.sin(radians)],
 			[Math.sin(radians), Math.cos(radians)]];
 


### PR DESCRIPTION
Align handling of orientation values with the desktop version turning positive angles into clockwise rotations.

Preview:
[simplistic-stick.surge.sh](http://simplistic-stick.surge.sh)

@apitiot Closes #87? @peircej CSS transforms work like PsychoPy's.