### PR TITLE
visual/VisualStim: move contains method from movie to parent class

### DIFF
--- a/js/visual/MovieStim.js
+++ b/js/visual/MovieStim.js
@@ -285,42 +285,6 @@ export class MovieStim extends VisualStim
 
 
 	/**
-	 * Determine whether the given object is inside this movie.
-	 *
-	 * @name module:visual.MovieStim#contains
-	 * @public
-	 * @param {Object} object - the object
-	 * @param {string} units - the units
-	 * @return {boolean} whether or not the image contains the object
-	 */
-	contains(object, units)
-	{
-		// get position of object:
-		let objectPos_px = util.getPositionFromObject(object, units);
-		if (typeof objectPos_px === 'undefined')
-		{
-			throw {
-				origin: 'MovieStim.contains',
-				context: `when determining whether MovieStim: ${this._name} contains object: ${util.toString(object)}`,
-				error: 'unable to determine the position of the object'
-			};
-		}
-
-		// test for inclusion:
-		// note: since _pixi.anchor is [0.5, 0.5] the movie is actually centered on pos
-		let pos_px = util.to_px(this.pos, this.units, this._win);
-		let size_px = util.to_px(this.size, this.units, this._win);
-		const polygon_px = [
-			[pos_px[0] - size_px[0] / 2, pos_px[1] - size_px[1] / 2],
-			[pos_px[0] + size_px[0] / 2, pos_px[1] - size_px[1] / 2],
-			[pos_px[0] + size_px[0] / 2, pos_px[1] + size_px[1] / 2],
-			[pos_px[0] - size_px[0] / 2, pos_px[1] + size_px[1] / 2]];
-
-		return util.IsPointInsidePolygon(objectPos_px, polygon_px);
-	}
-
-
-	/**
 	 * Update the stimulus, if necessary.
 	 *
 	 * @name module:visual.MovieStim#_updateIfNeeded

--- a/js/visual/Slider.js
+++ b/js/visual/Slider.js
@@ -135,33 +135,6 @@ export class Slider extends util.mix(VisualStim).with(ColorMixin)
 
 
 	/**
-	 * Determine whether an object is inside the bounding box of the slider.
-	 *
-	 * @name module:visual.Slider#contains
-	 * @public
-	 * @param {Object} object - the object
-	 * @param {string} units - the units
-	 * @return {boolean} whether or not the object is inside the bounding box of the slider
-	 *
-	 * @todo this is currently not implemented and always returns false
-	 */
-	contains(object, units)
-	{
-		// get position of object:
-		let objectPos_px = util.getPositionFromObject(object, units);
-		if (typeof objectPos_px === 'undefined')
-		{
-			throw {
-				origin: 'Slider.contains', context: `when determining whether Slider: ${this._name} contains
-			object: ${util.toString(object)}`, error: 'unable to determine the position of the object'
-			};
-		}
-
-		return false;
-	}
-
-
-	/**
 	 * Reset the slider.
 	 *
 	 * @name module:visual.Slider#reset

--- a/js/visual/TextStim.js
+++ b/js/visual/TextStim.js
@@ -244,36 +244,6 @@ export class TextStim extends util.mix(VisualStim).with(ColorMixin)
 
 
 	/**
-	 * Determine whether an object is inside the bounding box of the text.
-	 *
-	 * @name module:visual.TextStim#contains
-	 * @public
-	 * @param {Object} object - the object
-	 * @param {string} units - the units
-	 * @return {boolean} whether or not the object is inside the bounding box of the text
-	 *
-	 * @todo this is currently NOT implemented
-	 */
-	contains(object, units)
-	{
-		// get position of object:
-		let objectPos_px = util.getPositionFromObject(object, units);
-		if (typeof objectPos_px === 'undefined')
-		{
-			throw {
-				origin: 'TextStim.contains',
-				context: 'when determining whether TextStim: ' + this._name + ' contains object: ' + util.toString(object),
-				error: 'unable to determine the position of the object'
-			};
-		}
-
-		// test for inclusion:
-		// TODO
-		return false;
-	}
-
-
-	/**
 	 * Update the stimulus, if necessary.
 	 *
 	 * @name module:visual.TextStim#_updateIfNeeded

--- a/js/visual/VisualStim.js
+++ b/js/visual/VisualStim.js
@@ -66,6 +66,44 @@ export class VisualStim extends util.mix(MinimalStim).with(WindowMixin)
 
 
 	/**
+	 * Determine whether the given object is inside this stimulus.
+	 *
+	 * @name module:visual.VisualStim#contains
+	 * @public
+	 * @param {Object} object - the object
+	 * @param {string} units - the units
+	 * @return {boolean} whether or not the stimulus bounding box contains the object
+	 */
+	contains(object, units)
+	{
+		// get position of object:
+		let objectPos_px = util.getPositionFromObject(object, units);
+		if (typeof objectPos_px === 'undefined')
+		{
+			const constructorName = this.constructor.name
+
+			throw {
+				origin: `${constructorName}.contains`,
+				context: `when determining whether ${constructorName}: ${this._name} contains object: ${util.toString(object)}`,
+				error: 'unable to determine the position of the object'
+			};
+		}
+
+		// test for inclusion:
+		// note: since _pixi.anchor is [0.5, 0.5] the movie is actually centered on pos
+		let pos_px = util.to_px(this.pos, this.units, this._win);
+		let size_px = util.to_px(this.size, this.units, this._win);
+		const polygon_px = [
+			[pos_px[0] - size_px[0] / 2, pos_px[1] - size_px[1] / 2],
+			[pos_px[0] + size_px[0] / 2, pos_px[1] - size_px[1] / 2],
+			[pos_px[0] + size_px[0] / 2, pos_px[1] + size_px[1] / 2],
+			[pos_px[0] - size_px[0] / 2, pos_px[1] + size_px[1] / 2]];
+
+		return util.IsPointInsidePolygon(objectPos_px, polygon_px);
+	}
+
+
+	/**
 	 * Setter for the size attribute.
 	 *
 	 * @name module:visual.VisualStim#setSize


### PR DESCRIPTION
@apitiot @peircej Move `MovieStim.contains()` up to the parent class of `VisualStim`, enable for `TextStim` and `Slider` modules. Please note, clicks detected on bounding box, not text outline path. Closes #55?

Issue #55 preview:
https://run.pavlovia.org/dvbridges/textcontains/html/

With changes applied:
http://successful-shop.surge.sh