### PR TITLE
core/Mouse: add isPressedIn method

### DIFF
--- a/js/core/Mouse.js
+++ b/js/core/Mouse.js
@@ -149,23 +149,27 @@ export class Mouse extends PsychObject
 		}
 	}
 
+
 	/**
 	 * Helper method for checking whether a stimulus has had any button presses within bounds.
 	 *
 	 * @name module:core.Mouse#isPressedIn
 	 * @function
 	 * @public
-	 * @param {object|module:visual.VisualStim} [shape= undefined] A type of stimulus implementing a `contains()` method.
-	 * @param {object|number} [buttons= undefined] The target button index.
+	 * @param {object|module:visual.VisualStim} shape A type of visual stimulus or object having a `contains()` method.
+	 * @param {object|number} [buttons] The target button index potentially tucked inside an object.
+	 * @param {object} [options]
+	 * @param {object|module:visual.VisualStim} [options.shape]
+	 * @param {number} [options.buttons]
 	 * @return {boolean} Whether mouse with button(s) pressed is contained within stimulus.
 	 */
 	isPressedIn(...args)
 	{
-		// Helper to check if some object features a certain key
-		const hasKey = key => object => !!(object && object[key]);
-
 		// Look for options given in object literal form, cut out falsy inputs
 		const [{ shape: shapeMaybe, buttons: buttonsMaybe } = {}] = args.filter(v => !!v);
+
+		// Helper to check if some object features a certain key
+		const hasKey = key => object => !!(object && object[key]);
 
 		// Shapes are expected to be instances of stimuli, or at
 		// the very least objects featuring a `contains()` method

--- a/js/core/Mouse.js
+++ b/js/core/Mouse.js
@@ -149,6 +149,33 @@ export class Mouse extends PsychObject
 		}
 	}
 
+	/**
+	 * Helper method for checking whether a stimulus has had any button presses within bounds.
+	 *
+	 * <p>Note: Since there can only be one button pressed at a time, there is no point passing in a "buttons" array like PsychoPy. Pass in a "wanted" array index for the target button instead.</p>
+	 *
+	 * @name module:core.Mouse#isPressedIn
+	 * @function
+	 * @public
+	 * @param {object|module:visual.VisualStim} [stimulus= undefined] A type of stimulus implementing a `contains()` method.
+	 * @param {number} [wanted= undefined] The target button index.
+	 * @return {boolean} Whether mouse with button(s) pressed is contained within stimulus.
+	 */
+	isPressedIn(stimulus, wanted)
+	{
+		// Will throw if stimulus is falsy or non-object like
+		if (typeof stimulus.contains === 'function')
+		{
+			const { buttons } = this.psychoJS.eventManager.getMouseInfo();
+			// If no specific button wanted, any pressed will do
+			const pressed = Number.isInteger(wanted) ? buttons.pressed[wanted] > 0 : buttons.pressed.some(v => v > 0);
+
+			return pressed && stimulus.contains(this);
+		}
+
+		return false;
+	}
+
 
 	/**
 	 * Determine whether the mouse has moved beyond a certain distance.

--- a/js/core/Mouse.js
+++ b/js/core/Mouse.js
@@ -161,7 +161,7 @@ export class Mouse extends PsychObject
 	 * @param {object} [options]
 	 * @param {object|module:visual.VisualStim} [options.shape]
 	 * @param {number} [options.buttons]
-	 * @return {boolean} Whether mouse with button(s) pressed is contained within stimulus.
+	 * @return {boolean} Whether button pressed is contained within stimulus.
 	 */
 	isPressedIn(...args)
 	{

--- a/js/core/Mouse.js
+++ b/js/core/Mouse.js
@@ -176,16 +176,16 @@ export class Mouse extends PsychObject
 		// Default to input (pass through)
 		const shape = shapeFound || shapeMaybe;
 
-		// Buttons values may be extracted from an object literal
+		// Buttons values may be extracted from an object
 		// featuring the `buttons` key, or found as integers
 		// in the arguments array
 		const hasButtons = hasKey('buttons');
 		const { isInteger } = Number;
-		// Prioritize buttons value given as part of an options object literal,
+		// Prioritize buttons value given as part of an options object,
 		// then look for the first occurrence in the arguments array of either
 		// an integer or an extra object with a `buttons` key
 		const buttonsFound = isInteger(buttonsMaybe) ? buttonsMaybe : args.find(o => hasButtons(o) || isInteger(o));
-		// Worst case scenario `wanted` ends up being an empty object literal
+		// Worst case scenario `wanted` ends up being an empty object
 		const { buttons: wanted = buttonsFound || buttonsMaybe } = buttonsFound || {};
 
 		// Will throw if stimulus is falsy or non-object like


### PR DESCRIPTION
@apitiot @peircej Implement `Mouse.isPressedIn()` with a slightly different signature to PsychoPy when it comes to targeting a specific button. Closes #104?

Demo:
http://succinct-harbor.surge.sh