### PR TITLE
Call destroy on internal _pixi instance across visual stimuli

### DIFF
--- a/js/visual/ImageStim.js
+++ b/js/visual/ImageStim.js
@@ -268,6 +268,14 @@ export class ImageStim extends util.mix(VisualStim).with(ColorMixin)
 		}
 		this._needUpdate = false;
 
+		// Guard against memory leaks
+		// https://discourse.psychopy.org/t/psychojs-platform-version-2020-1-memory-leak-in-visual-stimulus-setters/14571
+		// https://www.html5gamedevs.com/topic/1189-pixi-how-to-destroy-cleanup/
+		if (typeof this._pixi !== 'undefined')
+		{
+			this._pixi.destroy(true);
+		}
+
 		this._pixi = undefined;
 
 		// no image to draw: return immediately

--- a/js/visual/MovieStim.js
+++ b/js/visual/MovieStim.js
@@ -334,6 +334,12 @@ export class MovieStim extends VisualStim
 		}
 		this._needUpdate = false;
 
+		// Guard against memory leaks
+		if (typeof this._pixi !== 'undefined')
+		{
+			this._pixi.destroy(true);
+		}
+
 		this._pixi = undefined;
 
 		// no movie to draw: return immediately

--- a/js/visual/ShapeStim.js
+++ b/js/visual/ShapeStim.js
@@ -252,6 +252,12 @@ export class ShapeStim extends util.mix(VisualStim).with(ColorMixin)
 
 		this._getPolygon(/*true*/); // this also updates _vertices_px
 
+		// Guard against memory leaks
+		if (typeof this._pixi !== 'undefined')
+		{
+			this._pixi.destroy(true);
+		}
+
 		this._pixi = undefined;
 
 		// no polygon to draw: return immediately

--- a/js/visual/TextStim.js
+++ b/js/visual/TextStim.js
@@ -297,6 +297,13 @@ export class TextStim extends util.mix(VisualStim).with(ColorMixin)
 			(this._bold ? 'bold ' : '') +
 			(this._italic ? 'italic ' : '') +
 			fontSize + 'px ' + this._font;
+
+		// Guard against memory leaks
+		if (typeof this._pixi !== 'undefined')
+		{
+			this._pixi.destroy(true);
+		}
+
 		this._pixi = new PIXI.Text(this._text, {
 			font: font,
 			fill: color.hex,


### PR DESCRIPTION
@peircej @apitiot Add guards against memory leaks as described in #97, possibly addresses #77 as well.