### PR TITLE
visual/Movie: add currentTime fallback when video seeking

### DIFF
--- a/js/visual/MovieStim.js
+++ b/js/visual/MovieStim.js
@@ -210,10 +210,7 @@ export class MovieStim extends VisualStim
 	{
 		this.status = PsychoJS.Status.NOT_STARTED;
 		this._movie.pause();
-		if (this._hasFastSeek)
-		{
-			this._movie.fastSeek(0);
-		}
+		this.seek(0, log);
 	}
 
 
@@ -250,10 +247,7 @@ export class MovieStim extends VisualStim
 	{
 		this.status = PsychoJS.Status.STOPPED;
 		this._movie.pause();
-		if (this._hasFastSeek)
-		{
-			this._movie.fastSeek(0);
-		}
+		this.seek(0, log);
 	}
 
 
@@ -280,6 +274,21 @@ export class MovieStim extends VisualStim
 		if (this._hasFastSeek)
 		{
 			this._movie.fastSeek(timePoint);
+		}
+		else
+		{
+			try
+			{
+				this._movie.currentTime = timePoint;
+			}
+			catch (error)
+			{
+				throw {
+					origin: 'MovieStim.seek',
+					context: `when seeking to timepoint: ${timePoint} of MovieStim: ${this._name}`,
+					error
+				};
+			}
 		}
 	}
 


### PR DESCRIPTION
@peircej @apitiot  Have `MovieStim.seek()` try setting `currentTime` on the underlying `this._movie` video element if `fastSeek()` is unavailable and DRY up `stop()` and `reset()` accordingly. This should provide better browser support, but issue #133 could also be due to PsychoPy generated JS code lacking `reset()` calls when initiating new trials (in a loop).

Demo in which movie playback will reset once nine seconds in:
http://lacking-shoe.surge.sh