### PR TITLE
visual/MovieStim: DOM clone video baseTexture during setMovie call

### DIFF
--- a/js/visual/MovieStim.js
+++ b/js/visual/MovieStim.js
@@ -126,13 +126,19 @@ export class MovieStim extends VisualStim
 				this.psychoJS.logger.debug(`set the movie of MovieStim: ${this._name} as: src= ${movie.src}, size= ${movie.videoWidth}x${movie.videoHeight}, duration= ${movie.duration}s`);
 			}
 
-			this._setAttribute('movie', movie, log);
+			const clone = movie.cloneNode();
 
-			// change status of stimulus when movie finish playing:
-			this._movie.onended = () =>
+			this._setAttribute('movie', clone, log);
+
+			const onended = () =>
 			{
+				// Change stimulus status when movie done playing
 				this.status = PsychoJS.Status.FINISHED;
+				// Equivalent to giving the listener below an option of `{ once: true }`
+				this._movie.removeEventListener('ended', onended);
 			};
+
+			this._movie.addEventListener('ended', onended);
 
 			this._needUpdate = true;
 		}


### PR DESCRIPTION
@peircej @apitiot A JS only workaround to avoid flashing of frames when playing movies in repeat over multiple trials. Please find a test case fork also highlighting a couple of code generation bits potentially off balance below,
https://gitlab.pavlovia.org/thewhodidthis/testmovie2

Closes #133 and closes #140?