### PR TITLE
core/Window: lose gl extension context before PIXI renderer

### DIFF
--- a/js/core/Window.js
+++ b/js/core/Window.js
@@ -127,13 +127,10 @@ export class Window extends PsychObject
 		if (typeof this._renderer.gl !== 'undefined')
 		{
 			const extension = this._renderer.gl.getExtension('WEBGL_lose_context');
-			this._renderer.destroy();
 			extension.loseContext();
 		}
-		else
-		{
-			this._renderer.destroy();
-		}
+
+		this._renderer.destroy();
 
 		window.removeEventListener('resize', this._resizeCallback);
 		window.removeEventListener('orientationchange', this._resizeCallback);


### PR DESCRIPTION
@peircej @apitiot When closing the PsychoJS window, it appears destroying the internal renderer ahead of losing context was the cause of the problem. Closes #116?

[gitlab.pavlovia.org/thewhodidthis/testmovie2/tree/bf#116--movie](https://gitlab.pavlovia.org/thewhodidthis/testmovie2/tree/bf%23116--movie)