### PR TITLE
util/ColorMixin: force a PIXI update when setting color or contrast

### DIFF
--- a/js/util/ColorMixin.js
+++ b/js/util/ColorMixin.js
@@ -39,6 +39,7 @@ export let ColorMixin = (superclass) => class extends superclass
 		this._setAttribute('color', color, log);
 
 		this._needUpdate = true;
+		this._needPixiUpdate = true;
 	}
 
 
@@ -56,6 +57,7 @@ export let ColorMixin = (superclass) => class extends superclass
 		this._setAttribute('contrast', contrast, log);
 
 		this._needUpdate = true;
+		this._needPixiUpdate = true;
 	}
 
 


### PR DESCRIPTION
@peircej @apitiot Have `ColorMixin` reflect that for visual components like `TextStim` changing 'color' and 'contrast' attributes [needs PIXI related calls](psychopy/psychojs/blob/master/js/visual/TextStim.js#L306). The same result can be achieved as shown below, but simply setting `this._needPixiUpdate = true;` requires no checks. Closes #148?

```js
if (typeof this._onChange === 'function')
{
  this._onChange(true, false)();
}
```