### PR TITLE
visual/MovieStim: add interpolate when destructuring options on init

### DIFF
--- a/js/visual/MovieStim.js
+++ b/js/visual/MovieStim.js
@@ -47,7 +47,7 @@ import {PsychoJS} from "../core/PsychoJS";
  */
 export class MovieStim extends VisualStim
 {
-	constructor({name, win, movie, pos, units, ori, size, color, opacity, contrast, flipHoriz, flipVert, loop, volume, noAudio, autoPlay, autoDraw, autoLog} = {})
+	constructor({name, win, movie, pos, units, ori, size, color, opacity, contrast, interpolate, flipHoriz, flipVert, loop, volume, noAudio, autoPlay, autoDraw, autoLog} = {})
 	{
 		super({name, win, units, ori, opacity, pos, size, autoDraw, autoLog});
 


### PR DESCRIPTION
@apitiot It appears 6e8f3bf612f5895afbd243098bcdb83c1260fe0c edits in the handling of argument defaults in class constructors left out 'interpolation' for `MovieStim`, closes #150 