### PR TITLE
visual/MovieStim: tweak options when destroying pixi sprite

### DIFF
--- a/js/visual/MovieStim.js
+++ b/js/visual/MovieStim.js
@@ -334,7 +334,13 @@ export class MovieStim extends VisualStim
 
 			if (typeof this._pixi !== 'undefined')
 			{
-				this._pixi.destroy(true);
+				// Leave original video in place
+				// https://pixijs.download/dev/docs/PIXI.Sprite.html#destroy
+				this._pixi.destroy({
+					children: true,
+					texture: true,
+					baseTexture: false
+				});
 			}
 			this._pixi = undefined;
 


### PR DESCRIPTION
@apitiot @peircej Destroy main texture and children, but leave baseTexture untouched, closes #142?