### PR TITLE
sound/TrackPlayer: add setDuration()

### DIFF
--- a/js/sound/Sound.js
+++ b/js/sound/Sound.js
@@ -168,7 +168,7 @@ export class Sound extends PsychObject
 	 *
 	 * @public
 	 * @param {number} [secs=0.5] - duration of the tone (in seconds) If secs == -1, the sound will play indefinitely.
-	 * @param {boolean} [log=true] - whether of not to log
+	 * @param {boolean} [log=true] - whether or not to log
 	 */
 	setSecs(secs = 0.5, log = true)
 	{

--- a/js/sound/TonePlayer.js
+++ b/js/sound/TonePlayer.js
@@ -130,7 +130,7 @@ export class TonePlayer extends SoundPlayer
 	 * @name module:sound.TonePlayer#setDuration
 	 * @function
 	 * @public
-	 * @param {Integer} duration_s - dthe uration of the tone (in seconds) If duration_s == -1, the sound will play indefinitely.
+	 * @param {number} duration_s - the duration of the tone (in seconds) If duration_s == -1, the sound will play indefinitely.
 	 */
 	setDuration(duration_s)
 	{

--- a/js/sound/TrackPlayer.js
+++ b/js/sound/TrackPlayer.js
@@ -110,7 +110,7 @@ export class TrackPlayer extends SoundPlayer
 	{
 		if (typeof this._howl !== 'undefined')
 		{
-			// Unfortunately Howler.js provides no shorthand duration setter
+			// Unfortunately Howler.js provides duration setting method
 			this._howl._duration = duration_s;
 		}
 	}

--- a/js/sound/TrackPlayer.js
+++ b/js/sound/TrackPlayer.js
@@ -99,6 +99,24 @@ export class TrackPlayer extends SoundPlayer
 
 
 	/**
+	 * Set the duration of the default sprite.
+	 *
+	 * @name module:sound.TrackPlayer#setDuration
+	 * @function
+	 * @public
+	 * @param {number} duration_s - the duration of the track in seconds
+	 */
+	setDuration(duration_s)
+	{
+		if (typeof this._howl !== 'undefined')
+		{
+			// Unfortunately Howler.js provides no shorthand duration setter
+			this._howl._duration = duration_s;
+		}
+	}
+
+
+	/**
 	 * Set the volume of the tone.
 	 *
 	 * @name module:sound.TrackPlayer#setVolume


### PR DESCRIPTION
@apitiot @peircej This would be one way of having Howler.js adjust the duration of the default sprite that gets created when initialising the player for an audio resource during the download process. The Tone.js based `TonePlayer` class already offers this type of setting.

Please note that for both players setting playback duration is actually available through `setSecs()` on a `Sound` instance. Also, while the `stopTime` attribute remains unchanged, it does end up getting ignored in practice when the duration is set after first creating a `Sound` object. Closes #131?