### PR TITLE
sound/TonePlayer: fix triggerRelease

### DIFF
--- a/js/sound/TonePlayer.js
+++ b/js/sound/TonePlayer.js
@@ -266,7 +266,7 @@ export class TonePlayer extends SoundPlayer
 		if (this._soundLibrary === TonePlayer.SoundLibrary.TONE_JS)
 		{
 			// trigger the release of the sound, immediately:
-			this._synth.triggerRelease();
+			this._synth.triggerRelease(this._note);
 
 			// clear the repeat event if need be:
 			if (this._toneId)


### PR DESCRIPTION
@apitiot As it happens, the `triggerRelease()` call as part of `TonePlayer.stop()` needs a note value argument to run smoothly, same as `triggerAttackRelease()` inside of `playToneCallback()`. Closes #155.