### PR TITLE
visual/TextBox: Add methods for accessing the underlying input text

### DIFF
--- a/js/visual/TextBox.js
+++ b/js/visual/TextBox.js
@@ -165,6 +165,49 @@ export class TextBox extends util.mix(VisualStim).with(ColorMixin)
 	}
 
 
+	/**
+	 * Clears the current text value.
+	 *
+	 * @name module:visual.TextBox#reset
+	 * @public
+	 */
+	reset()
+	{
+		this.setInputText();
+	}
+
+
+	/**
+	 * For tweaking the underlying input value.
+	 *
+	 * @name module:visual.TextBox#setInputText
+	 * @public
+	 * @param {string} text
+	 */
+	setInputText(text = '')
+	{
+		if (typeof this._pixi !== 'undefined')
+		{
+			this._pixi.text = text;
+		}
+	}
+
+
+	/**
+	 * For accessing the underlying input value.
+	 *
+	 * @name module:visual.TextBox#getInputText
+	 * @public
+	 * @return {string} - the current text value of the underlying input element.
+	 */
+	getInputText()
+	{
+		if (typeof this._pixi !== 'undefined')
+		{
+			return this._pixi.text;
+		}
+	}
+
 
 	/**
 	 * Setter for the size attribute.

--- a/js/visual/TextBox.js
+++ b/js/visual/TextBox.js
@@ -173,39 +173,43 @@ export class TextBox extends util.mix(VisualStim).with(ColorMixin)
 	 */
 	reset()
 	{
-		this.setInputText();
+		this.setText();
 	}
 
 
 	/**
 	 * For tweaking the underlying input value.
 	 *
-	 * @name module:visual.TextBox#setInputText
+	 * @name module:visual.TextBox#setText
 	 * @public
 	 * @param {string} text
 	 */
-	setInputText(text = '')
+	setText(text = '')
 	{
 		if (typeof this._pixi !== 'undefined')
 		{
 			this._pixi.text = text;
 		}
+
+		this._text = text;
 	}
 
 
 	/**
 	 * For accessing the underlying input value.
 	 *
-	 * @name module:visual.TextBox#getInputText
+	 * @name module:visual.TextBox#getText
 	 * @public
 	 * @return {string} - the current text value of the underlying input element.
 	 */
-	getInputText()
+	getText()
 	{
 		if (typeof this._pixi !== 'undefined')
 		{
 			return this._pixi.text;
 		}
+
+		return this._text;
 	}
 
 


### PR DESCRIPTION
@apitiot Because when editable, reading the `TextBox.text` attribute will only return the initial value. Closes #159 and closes #160? 