### PR TITLE
data/util: Have util export turnSquareBracketsIntoArrays, fix when called inside of importConditions

### DIFF
--- a/js/data/TrialHandler.js
+++ b/js/data/TrialHandler.js
@@ -467,12 +467,6 @@ export class TrialHandler extends PsychObject
 					{
 						let value = row[l];
 
-						// if value is a numerical string, convert it to a number:
-						if (typeof value === 'string' && !isNaN(value))
-						{
-							value = Number.parseFloat(value);
-						}
-
 						// Look for string encoded arrays in the form of '[1, 2]'
 						const arrayMaybe = util.turnSquareBracketsIntoArrays(value);
 
@@ -480,8 +474,15 @@ export class TrialHandler extends PsychObject
 						{
 							// Keep the first match if more than one are found. If the
 							// input string looked like '[1, 2][3, 4]' for example,
-							// the resulting value would be [1, 2]
+							// the resulting value would be [1, 2]. When `arrayMaybe` is
+							// empty, value turns `undefined`.
 							value = arrayMaybe[0];
+						}
+
+						// if value is a numerical string, convert it to a number:
+						if (typeof value === 'string' && !isNaN(value))
+						{
+							value = Number.parseFloat(value);
 						}
 
 						trial[fields[l]] = value;

--- a/js/data/TrialHandler.js
+++ b/js/data/TrialHandler.js
@@ -473,11 +473,15 @@ export class TrialHandler extends PsychObject
 							value = Number.parseFloat(value);
 						}
 
-						const [arrayMaybe] = util.turnSquareBracketsIntoArrays(value);
+						// Look for string encoded arrays in the form of '[1, 2]'
+						const arrayMaybe = util.turnSquareBracketsIntoArrays(value);
 
 						if (Array.isArray(arrayMaybe))
 						{
-							value = arrayMaybe;
+							// Keep the first match if more than one are found. If the
+							// input string looked like '[1, 2][3, 4]' for example,
+							// the resulting value would be [1, 2]
+							value = arrayMaybe[0];
 						}
 
 						trial[fields[l]] = value;

--- a/js/data/TrialHandler.js
+++ b/js/data/TrialHandler.js
@@ -475,7 +475,7 @@ export class TrialHandler extends PsychObject
 							// Keep the first match if more than one are found. If the
 							// input string looked like '[1, 2][3, 4]' for example,
 							// the resulting `value` would be [1, 2]. When `arrayMaybe` is
-							// empty, value turns `undefined`. At this point that might
+							// empty, `value` turns `undefined`. At this point that might
 							// only happen if `value` is an empty array to begin with.
 							value = arrayMaybe[0];
 						}

--- a/js/data/TrialHandler.js
+++ b/js/data/TrialHandler.js
@@ -474,8 +474,9 @@ export class TrialHandler extends PsychObject
 						{
 							// Keep the first match if more than one are found. If the
 							// input string looked like '[1, 2][3, 4]' for example,
-							// the resulting value would be [1, 2]. When `arrayMaybe` is
-							// empty, value turns `undefined`.
+							// the resulting `value` would be [1, 2]. When `arrayMaybe` is
+							// empty, value turns `undefined`. At this point that might
+							// only happen if `value` is an empty array to begin with.
 							value = arrayMaybe[0];
 						}
 

--- a/js/util/Util.js
+++ b/js/util/Util.js
@@ -966,7 +966,7 @@ export function offerDataForDownload(filename, data, type)
  * @param {string} input - string containing lists in square brackets
  * @returns {array} an array of arrays found
  */
-function turnSquareBracketsIntoArrays(input)
+export function turnSquareBracketsIntoArrays(input)
 {
 	// Only interested in strings
 	// https://stackoverflow.com/questions/4059147


### PR DESCRIPTION
@peircej @apitiot The problem here was an attempted destructuring assignment inside of `TrialHandler.importConditions()`. Please note that, like before, if a cell is found to contain more than one array looking substrings, [only the first match is kept](https://github.com/thewhodidthis/psychojs/blob/bf%23165--data/js/data/TrialHandler.js#L481). Closes #165?