### PR TITLE
visual/ImageStim: tweak _estimateBoundingBox() to use size over this._size

### DIFF
--- a/js/visual/ImageStim.js
+++ b/js/visual/ImageStim.js
@@ -222,10 +222,10 @@ export class ImageStim extends util.mix(VisualStim).with(ColorMixin)
 		if (typeof size !== 'undefined')
 		{
 			this._boundingBox = new PIXI.Rectangle(
-				this._pos[0] - this._size[0] / 2,
-				this._pos[1] - this._size[1] / 2,
-				this._size[0],
-				this._size[1]
+				this._pos[0] - size[0] / 2,
+				this._pos[1] - size[1] / 2,
+				size[0],
+				size[1]
 			);
 		}
 


### PR DESCRIPTION
@apitiot Like #158 but for `visual.ImageStim`, closes #176. 