### PR TITLE
visual/MovieStim: deal with promise based video play

### DIFF
--- a/js/visual/MovieStim.js
+++ b/js/visual/MovieStim.js
@@ -219,7 +219,20 @@ export class MovieStim extends VisualStim
 	play(log = false)
 	{
 		this.status = PsychoJS.Status.STARTED;
-		this._movie.play();
+
+		// As found on https://goo.gl/LdLk22
+		const playPromise = this._movie.play();
+
+		if (playPromise !== undefined)
+		{
+			playPromise.catch((error) => {
+				throw {
+					origin: 'MovieStim.play',
+					context: `when attempting to play MovieStim: ${this._name}`,
+					error
+				};
+			});
+		}
 	}
 
 


### PR DESCRIPTION
@apitiot Not that the script won't run as is, but upgrading to PixiJS latest, as required to fully address #168, does log a console error without this, closes #169 and closes #184.