### PR TITLE
Post PIXI upgrade tweaks

### DIFF
--- a/js/core/Window.js
+++ b/js/core/Window.js
@@ -425,7 +425,9 @@ export class Window extends PsychObject
 		this._size[1] = window.innerHeight;
 
 		// create a PIXI renderer and add it to the document:
-		this._renderer = PIXI.autoDetectRenderer(this._size[0], this._size[1], {
+		this._renderer = PIXI.autoDetectRenderer({
+			width: this._size[0],
+			height: this._size[1],
 			backgroundColor: this.color.int,
 			resolution: window.devicePixelRatio
 		});

--- a/js/visual/MovieStim.js
+++ b/js/visual/MovieStim.js
@@ -172,20 +172,17 @@ export class MovieStim extends VisualStim
 				this.psychoJS.logger.debug(`set the movie of MovieStim: ${this._name} as: src= ${movie.src}, size= ${movie.videoWidth}x${movie.videoHeight}, duration= ${movie.duration}s`);
 			}
 
-			const clone = movie.cloneNode();
-
-			this._setAttribute('movie', clone, log);
-
-			const onended = () =>
+			// Make sure just one listener attached across instances
+			// https://stackoverflow.com/questions/11455515
+			if (!movie.onended)
 			{
-				// Change stimulus status when movie done playing
-				this.status = PsychoJS.Status.FINISHED;
-				// Equivalent to giving the listener below an option of `{ once: true }`
-				this._movie.removeEventListener('ended', onended);
-			};
+				movie.onended = () =>
+				{
+					this.status = PsychoJS.Status.FINISHED;
+				};
+			}
 
-			this._movie.addEventListener('ended', onended);
-
+			this._setAttribute('movie', movie, log);
 			this._needUpdate = true;
 			this._needPixiUpdate = true;
 		}

--- a/js/visual/MovieStim.js
+++ b/js/visual/MovieStim.js
@@ -354,7 +354,7 @@ export class MovieStim extends VisualStim
 			}
 
 			// create a PixiJS video sprite:
-			this._texture = PIXI.Texture.fromVideo(this._movie);
+			this._texture = PIXI.Texture.from(this._movie);
 			this._pixi = new PIXI.Sprite(this._texture);
 
 			// since _texture.width may not be immedialy available but the rest of the code needs its value


### PR DESCRIPTION
@peircej @apitiot Upgrading to [PixiJS 5.3.3](https://github.com/pixijs/pixi.js/releases/tag/v5.3.3) seems necessary to address our video playback issues. This PR includes post upgrade edits required on our end, most importantly giving `autoDetectRenderer` a width and height as part of the options object instead of as separate arguments. Closes #168, but again is meant to be applied in combination with a PixiJS version bump :blush:

In action:
(a) [Start playing without having to wait &rsaquo;](https://run.pavlovia.org/thewhodidthis/multiplemovie)
(b) [Seamless repetition &rsaquo;](https://run.pavlovia.org/thewhodidthis/testmovie2/)