### PR TITLE
Do hide the "Initialising the experiment..." message on PsychoJS init

### DIFF
--- a/css/psychojs.css
+++ b/css/psychojs.css
@@ -138,6 +138,11 @@ a:hover {
   transform: translate(-50%, -50%);
 }
 
+/* Using double colons is the MDN recommended way */
+#root.is-ready::after {
+  display: none;
+}
+
 /* Initialisation message for IE11 */
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
   #root:after {

--- a/js/core/PsychoJS.js
+++ b/js/core/PsychoJS.js
@@ -165,6 +165,9 @@ export class PsychoJS
 
 		this.logger.info('[PsychoJS] Initialised.');
 		this.logger.info('[PsychoJS] @version 2020.2');
+
+		// Hide #root::after
+		$('#root').addClass('is-ready');
 	}
 
 


### PR DESCRIPTION
@apitiot Because pseudo elements are unavailable via DOM selectors, this is one relatively simple way of hiding `#root::after` by giving it an `.is-ready` class via jQuery, which is then defined in CSS, closes #175 

Demo: [run.pavlovia.org/thewhodidthis/blank &rarr;](https://run.pavlovia.org/thewhodidthis/blank/)