### PR TITLE
core/GUI: make sure _setRequiredKeys exists before accessing its size

### DIFF
--- a/js/core/GUI.js
+++ b/js/core/GUI.js
@@ -624,7 +624,7 @@ export class GUI
 	 */
 	_updateOkButtonStatus()
 	{
-		if (this._psychoJS.getEnvironment() === ExperimentHandler.Environment.LOCAL || (this._allResourcesDownloaded && this._setRequiredKeys.size >= this._requiredKeys.length))
+		if (this._psychoJS.getEnvironment() === ExperimentHandler.Environment.LOCAL || (this._allResourcesDownloaded && this._setRequiredKeys && this._setRequiredKeys.size >= this._requiredKeys.length))
 		{
 			$("#buttonOk").button("option", "disabled", false).focus();
 		}


### PR DESCRIPTION
@apitiot As documented [on discourse](https://discourse.psychopy.org/t/pavlovia-phaser3-tips-for-writing-data/16238/8) when using PsychoJS sans GUI on the server, closes #193 

Problem: [run.pavlovia.org/thewhodidthis/study-game-1 &rarr;](https://run.pavlovia.org/thewhodidthis/study-game-1/)
No problem: [run.pavlovia.org/thewhodidthis/download-resources-not &rarr;](https://run.pavlovia.org/thewhodidthis/download-resources-not/)