### PR TITLE
util/Util: tweak toNumerical error throwing to not rely on this._gui

### DIFF
--- a/js/util/Util.js
+++ b/js/util/Util.js
@@ -281,8 +281,7 @@ export function toNumerical(obj)
 	}
 	catch (error)
 	{
-		// this._gui.dialog({ error: { ...response, error } });
-		this._gui.dialog({ error: Object.assign(response, { error }) });
+		throw Object.assign(response, { error });
 	}
 
 }


### PR DESCRIPTION
@apitiot It appears that going through `this._gui.dialog()` for error display can be avoided in this case? Closes #189 
