### PR TITLE
util/Util: tweak toNumerical() to match JSDoc comment

### DIFF
--- a/js/util/Util.js
+++ b/js/util/Util.js
@@ -265,7 +265,7 @@ export function toNumerical(obj)
 
 			if (Number.isNaN(n))
 			{
-				throw `unable to convert ${e} to a number`;
+				throw `unable to convert ${input} to a number`;
 			}
 
 			return n;

--- a/js/util/Util.js
+++ b/js/util/Util.js
@@ -259,22 +259,26 @@ export function toNumerical(obj)
 			return obj;
 		}
 
+		const convertToNumber = (input) =>
+		{
+			const n = Number.parseFloat(input);
+
+			if (Number.isNaN(n))
+			{
+				throw `unable to convert ${e} to a number`;
+			}
+
+			return n;
+		}
+
 		if (typeof obj === 'string')
 		{
-			obj = [obj];
+			return convertToNumber(obj);
 		}
 
 		if (Array.isArray(obj))
 		{
-			return obj.map(e =>
-			{
-				let n = Number.parseFloat(e);
-				if (Number.isNaN(n))
-				{
-					throw `unable to convert ${e} to a number`;
-				}
-				return n;
-			});
+			return obj.map(convertToNumber);
 		}
 
 		throw 'unable to convert the object to a number';


### PR DESCRIPTION
@apitiot Closes #206 by way of amending `toNumerical()` to type coerce string input into its numerical form flat instead of inside of an array

Test: https://gist.github.com/thewhodidthis/95637b6a4d406900b5650111ac9a5446