### PR TITLE
Post Tone.js upgrade tweaks

### DIFF
--- a/js/core/GUI.js
+++ b/js/core/GUI.js
@@ -267,6 +267,9 @@ export class GUI
 								self._dialogComponent.button = 'OK';
 								$("#expDialog").dialog('close');
 
+								// Tackle browser demands on having user action initiate audio context
+								Tone.start();
+
 								// switch to full screen if requested:
 								self._psychoJS.window.adjustScreenSize();
 							}

--- a/js/sound/TonePlayer.js
+++ b/js/sound/TonePlayer.js
@@ -266,7 +266,7 @@ export class TonePlayer extends SoundPlayer
 		if (this._soundLibrary === TonePlayer.SoundLibrary.TONE_JS)
 		{
 			// trigger the release of the sound, immediately:
-			this._synth.triggerRelease(this._note);
+			this._synth.triggerRelease();
 
 			// clear the repeat event if need be:
 			if (this._toneId)
@@ -339,7 +339,7 @@ export class TonePlayer extends SoundPlayer
 			this._synth.connect(this._volumeNode);
 
 			// connect the volume node to the master output:
-			this._volumeNode.toMaster();
+			this._volumeNode.toDestination();
 
 		}
 		else


### PR DESCRIPTION
@peircej @apitiot Closes #211 provided [HTML boilerplate links to Tone.js latest](https://github.com/psychopy/psychopy/pull/3219), please note [the Tone.start() call](https://github.com/psychopy/psychojs/pull/212/files#diff-7bec8787bd851c93410746673590e3ad4405e8af797869569084ede5adb7d89bR270) as part of GUI's OK button click handler. Demo: [run.pavlovia.org/thewhodidthis/chromatic &rarr;](https://run.pavlovia.org/thewhodidthis/chromatic/)