### PR TITLE
data/TrialHandler: allow for doubly escaped LFs in xlsx cells

### DIFF
--- a/js/data/TrialHandler.js
+++ b/js/data/TrialHandler.js
@@ -482,11 +482,18 @@ export class TrialHandler extends PsychObject
 
 						if (typeof value === 'string')
 						{
-							// Parse doubly escaped line feeds
-							value = value.replace(/(\\n)/g, '\n');
+							const numberMaybe = Number.parseFloat(value);
 
 							// if value is a numerical string, convert it to a number:
-							value = isNaN(value) ? value : Number.parseFloat(value);
+							if (!isNaN(numberMaybe) && numberMaybe.toString().length === value.length)
+							{
+								value = numberMaybe;
+							}
+							else
+							{
+								// Parse doubly escaped line feeds
+								value = value.replace(/(\n)/g, '\n');
+							}
 						}
 
 						trial[fields[l]] = value;

--- a/js/data/TrialHandler.js
+++ b/js/data/TrialHandler.js
@@ -486,6 +486,12 @@ export class TrialHandler extends PsychObject
 							value = Number.parseFloat(value);
 						}
 
+						// Parse doubly escaped line feeds
+						if (typeof value === 'string')
+						{
+							value = value.replace(/(\\n)/g, '\n');
+						}
+
 						trial[fields[l]] = value;
 					}
 					trialList[r] = trial;

--- a/js/data/TrialHandler.js
+++ b/js/data/TrialHandler.js
@@ -482,11 +482,11 @@ export class TrialHandler extends PsychObject
 
 						if (typeof value === 'string')
 						{
-							// if value is a numerical string, convert it to a number:
-							value = Number.isNaN(value) ? value : Number.parseFloat(value);
-
 							// Parse doubly escaped line feeds
 							value = value.replace(/(\\n)/g, '\n');
+
+							// if value is a numerical string, convert it to a number:
+							value = isNaN(value) ? value : Number.parseFloat(value);
 						}
 
 						trial[fields[l]] = value;

--- a/js/data/TrialHandler.js
+++ b/js/data/TrialHandler.js
@@ -480,15 +480,12 @@ export class TrialHandler extends PsychObject
 							value = arrayMaybe[0];
 						}
 
-						// if value is a numerical string, convert it to a number:
-						if (typeof value === 'string' && !isNaN(value))
-						{
-							value = Number.parseFloat(value);
-						}
-
-						// Parse doubly escaped line feeds
 						if (typeof value === 'string')
 						{
+							// if value is a numerical string, convert it to a number:
+							value = Number.isNaN(value) ? value : Number.parseFloat(value);
+
+							// Parse doubly escaped line feeds
 							value = value.replace(/(\\n)/g, '\n');
 						}
 


### PR DESCRIPTION
@RebeccaHirst Closes #246, @apitiot please let me know if you would like to see a separate helper in Util. Please note that Alt + Enter may always be used to encode line feeds in .xlsx files instead of '\n'