### PR TITLE
core/GUI: refactor CSS naming of dialog box input elements

### DIFF
--- a/js/core/GUI.js
+++ b/js/core/GUI.js
@@ -133,63 +133,67 @@ export class GUI
 
 				// add a combobox or text areas for each entry in the dictionary:
 				htmlCode += '<form>';
-				for (const key in dictionary)
-				{
-					const value = dictionary[key];
-					const keyId = CSS.escape(key) + '_id';
 
-					// only create an input if the key is not in the URL:
-					let inUrl = false;
-					const cleanedDictKey = key.trim().toLowerCase();
-					infoFromUrl.forEach((urlValue, urlKey) =>
+				// These may include Symbols as opposed to when using a for...in loop,
+				// but only strings are allowed in PsychoPy
+				Object.keys(dictionary).forEach((key, keyIdx) =>
 					{
-						const cleanedUrlKey = urlKey.trim().toLowerCase();
-						if (cleanedUrlKey === cleanedDictKey)
+						const value = dictionary[key];
+						const keyId = 'form-input-' + keyIdx;
+
+						// only create an input if the key is not in the URL:
+						let inUrl = false;
+						const cleanedDictKey = key.trim().toLowerCase();
+						infoFromUrl.forEach((urlValue, urlKey) =>
+							{
+								const cleanedUrlKey = urlKey.trim().toLowerCase();
+								if (cleanedUrlKey === cleanedDictKey)
+								{
+									inUrl = true;
+									// break;
+								}
+							});
+
+						if (!inUrl)
 						{
-							inUrl = true;
-							// break;
-						}
-					});
+							htmlCode += '<label for="' + keyId + '">' + key + '</label>';
 
-					if (!inUrl)
-					{
-						htmlCode += '<label for="' + keyId + '">' + key + '</label>';
-
-						// if the field is required:
-						if (key.slice(-1) === '*')
-						{
-							self._requiredKeys.push(key);
-						}
-
-						// if value is an array, we create a select drop-down menu:
-						if (Array.isArray(value))
-						{
-							htmlCode += '<select name="' + key + '" id="' + keyId + '" class="text ui-widget-content' +
-								' ui-corner-all">';
-
-							// if the field is required, we add an empty option and select it:
+							// if the field is required:
 							if (key.slice(-1) === '*')
 							{
-								htmlCode += '<option disabled selected>...</option>';
+								self._requiredKeys.push(key);
 							}
 
-							for (const option of value)
+							// if value is an array, we create a select drop-down menu:
+							if (Array.isArray(value))
 							{
-								htmlCode += '<option>' + option + '</option>';
+								htmlCode += '<select name="' + key + '" id="' + keyId + '" class="text ui-widget-content' +
+									' ui-corner-all">';
+
+								// if the field is required, we add an empty option and select it:
+								if (key.slice(-1) === '*')
+								{
+									htmlCode += '<option disabled selected>...</option>';
+								}
+
+								for (const option of value)
+								{
+									htmlCode += '<option>' + option + '</option>';
+								}
+
+								htmlCode += '</select>';
+								$('#' + keyId).selectmenu({classes: {}});
 							}
 
-							htmlCode += '</select>';
-							$('#' + keyId).selectmenu({classes: {}});
-						}
-
-						// otherwise we use a single string input:
-						else /*if (typeof value === 'string')*/
-						{
-							htmlCode += '<input type="text" name="' + key + '" id="' + keyId;
-							htmlCode += '" value="' + value + '" class="text ui-widget-content ui-corner-all">';
+							// otherwise we use a single string input:
+							else /*if (typeof value === 'string')*/
+							{
+								htmlCode += '<input type="text" name="' + key + '" id="' + keyId;
+								htmlCode += '" value="' + value + '" class="text ui-widget-content ui-corner-all">';
+							}
 						}
 					}
-				}
+				);
 				htmlCode += '</form>';
 
 
@@ -215,15 +219,16 @@ export class GUI
 
 
 				// setup change event handlers for all required keys:
-				for (const key of this._requiredKeys)
-				{
-					const keyId = CSS.escape(key) + '_id';
-					const input = document.getElementById(keyId);
-					if (input)
+				Object.keys(this._requiredKeys).forEach((key, keyIdx) =>
 					{
-						input.oninput = (event) => GUI._onKeyChange(self, event);
+						const keyId = 'form-input-' + keyIdx;
+						const input = document.getElementById(keyId);
+						if (input)
+						{
+							input.oninput = (event) => GUI._onKeyChange(self, event);
+						}
 					}
-				}
+				);
 
 				// init and open the dialog box:
 				self._dialogComponent.button = 'Cancel';
@@ -256,14 +261,16 @@ export class GUI
 							{
 
 								// update dictionary:
-								for (const key in dictionary)
-								{
-									const input = document.getElementById(CSS.escape(key) + "_id");
-									if (input)
+								Object.keys(dictionary).forEach((key, keyIdx) =>
 									{
-										dictionary[key] = input.value;
+										const input = document.getElementById('form-input-' + keyIdx);
+										if (input)
+										{
+											dictionary[key] = input.value;
+										}
 									}
-								}
+								);
+
 
 								self._dialogComponent.button = 'OK';
 								$("#expDialog").dialog('close');

--- a/js/core/GUI.js
+++ b/js/core/GUI.js
@@ -161,7 +161,7 @@ export class GUI
 							// if the field is required:
 							if (key.slice(-1) === '*')
 							{
-								self._requiredKeys.push(key);
+								self._requiredKeys.push(keyId);
 							}
 
 							// if value is an array, we create a select drop-down menu:
@@ -219,9 +219,8 @@ export class GUI
 
 
 				// setup change event handlers for all required keys:
-				Object.keys(this._requiredKeys).forEach((key, keyIdx) =>
+				this._requiredKeys.forEach((keyId) =>
 					{
-						const keyId = 'form-input-' + keyIdx;
 						const input = document.getElementById(keyId);
 						if (input)
 						{


### PR DESCRIPTION
@apitiot As @bbonf points out, some versions of Win / Edge still in use fail to recognise `CSS.escape()`. One option would be to go back to using `jQuery.escapeSelector()`. Or, as shown here, we could do away with sanitising dictionary keys in `GUI.DlgFromDict()` and rely on plain indices for deriving the _id_ and label _for_ form input attributes. I have checked and these references are only found within that one method. Closes #215?

Demo:
[run.pavlovia.org/thewhodidthis/css-escape-not &rarr;](https://run.pavlovia.org/thewhodidthis/css-escape-not)