### PR TITLE
core/Keyboard: prevent default on keydown

### DIFF
--- a/js/core/Keyboard.js
+++ b/js/core/Keyboard.js
@@ -418,6 +418,7 @@ export class Keyboard extends PsychObject
 			self._psychoJS.logger.trace('keydown: ', event.key);
 
 			event.stopPropagation();
+			event.preventDefault();
 		});
 
 


### PR DESCRIPTION
@apitiot Closes #167, the issue seems gone on Safari latest anyways

Demo:
[run.pavlovia.org/thewhodidthis/beeping-not &rarr;](https://run.pavlovia.org/thewhodidthis/beeping-not/)