### PR TITLE
Implement Window.getActualFrameRate() to dynamically update monitorFramePeriod

### DIFF
--- a/js/core/Window.js
+++ b/js/core/Window.js
@@ -148,10 +148,7 @@ export class Window extends PsychObject
 	{
 		// gets updated frame by frame
 		const lastDelta = this.psychoJS.scheduler._lastDelta;
-		const fpsMaybe = 1000 / lastDelta;
-		// NB: calling `Number.isFinite()` might skip the implicit to number conversion, but
-		// would also need polyfilling for IE
-		const fps = isFinite(fpsMaybe) ? fpsMaybe : 60.0;
+		const fps = lastDelta === 0 ? 60.0 : 1000 / lastDelta;
 
 		return fps;
 	}

--- a/js/core/Window.js
+++ b/js/core/Window.js
@@ -41,7 +41,7 @@ export class Window extends PsychObject
 	 */
 	get monitorFramePeriod()
 	{
-		return this._monitorFramePeriod;
+		return 1.0 / this.getActualFrameRate();
 	}
 
 	constructor({
@@ -68,9 +68,6 @@ export class Window extends PsychObject
 
 		// setup PIXI:
 		this._setupPixi();
-
-		// monitor frame period:
-		this._monitorFramePeriod = 1.0 / this.getActualFrameRate();
 
 		this._frameCount = 0;
 
@@ -145,14 +142,18 @@ export class Window extends PsychObject
 	 * @name module:core.Window#getActualFrameRate
 	 * @function
 	 * @public
-	 * @return {number} always returns 60.0 at the moment
-	 *
-	 * @todo estimate the actual frame rate.
+	 * @return {number} rAF based delta time based approximation, 60.0 by default
 	 */
 	getActualFrameRate()
 	{
-		// TODO
-		return 60.0;
+		// gets updated frame by frame
+		const lastDelta = this.psychoJS.scheduler._lastDelta;
+		const fpsMaybe = 1000 / lastDelta;
+		// NB: calling `Number.isFinite()` might skip the implicit to number conversion, but
+		// would also need polyfilling for IE
+		const fps = isFinite(fpsMaybe) ? fpsMaybe : 60.0;
+
+		return fps;
 	}
 
 

--- a/js/util/Scheduler.js
+++ b/js/util/Scheduler.js
@@ -137,7 +137,7 @@ export class Scheduler
 	start()
 	{
 		const self = this;
-		let update = () =>
+		let update = (timestamp) =>
 		{
 			// stop the animation if need be:
 			if (self._stopAtNextUpdate)
@@ -155,6 +155,12 @@ export class Scheduler
 				self._status = Scheduler.Status.STOPPED;
 				return;
 			}
+
+			// store frame delta for `Window.getActualFrameRate()`
+			const lastTimestamp = self._lastTimestamp || timestamp;
+
+			self._lastDelta = timestamp - lastTimestamp;
+			self._lastTimestamp = timestamp;
 
 			// render the scene in the window:
 			self._psychoJS.window.render();

--- a/js/util/Scheduler.js
+++ b/js/util/Scheduler.js
@@ -157,7 +157,7 @@ export class Scheduler
 			}
 
 			// store frame delta for `Window.getActualFrameRate()`
-			const lastTimestamp = self._lastTimestamp || timestamp;
+			const lastTimestamp = self._lastTimestamp === undefined ? timestamp : self._lastTimestamp;
 
 			self._lastDelta = timestamp - lastTimestamp;
 			self._lastTimestamp = timestamp;


### PR DESCRIPTION
@apitiot Calculate FPS with every rAF call, closes #257 and closes #199 

Demo:
[run.pavlovia.org/thewhodidthis/rolling-fps-meter &rarr;](https://run.pavlovia.org/thewhodidthis/rolling-fps-meter)