### PR TITLE
BF: When closing DlgFromDict, call eventmanager.clearEvents to clear events accumulated during dialog to prevent subsequent routines picking up keypresses belonging to DlgFromDict

### DIFF
--- a/js/core/GUI.js
+++ b/js/core/GUI.js
@@ -275,7 +275,7 @@ export class GUI
 								self._psychoJS.window.adjustScreenSize();
                 
                 // Clear events (and keypresses) accumulated during the dialog
-                self._psychoJS.eventManager.clearEvents(undefined)
+                self._psychoJS.eventManager.clearEvents();
 							}
 						}
 					],

--- a/js/core/GUI.js
+++ b/js/core/GUI.js
@@ -273,6 +273,9 @@ export class GUI
 
 								// switch to full screen if requested:
 								self._psychoJS.window.adjustScreenSize();
+                
+                // Clear events (and keypresses) accumulated during the dialog
+                self._psychoJS.eventManager.clearEvents(undefined)
 							}
 						}
 					],


### PR DESCRIPTION
Since DlgFromDict does not consume any events or keypresses, PsychoJS._keybuffer will be full of keypresses which may cause undesired outcomes when the experiment starts and the keypresses are processed.

Example bug-causing sequence:
- User presses ESC during DlgFromDict
- Nothing appears to happen (correct expected result)
- User completes the fields on DlgFromDict and presses Ok
- Next routine starts and then...

Bug behavior:
- User is unexpectedly presented with a "The [Escape] key was pressed. Goodbye!" dialog.

Correct behavior:
- Nothing should happen. ESC was pressed during the DIgFromDict, not this routine.

Reason the bug happens:
The ESC keypress during DlgFromDict was not consumed, so it is picked up by a [routine_name]RoutineEachFrame() in the scheduler, which checks for ESC keypresses, finds a ESC in the keybuffer, and unexpectedly stops the experiment.