### PR TITLE
BF: When switching to fullscreen after DlgFromDict, wait for completion of fullscreen transition before proceeding

### DIFF
--- a/js/core/GUI.js
+++ b/js/core/GUI.js
@@ -285,7 +285,13 @@ export class GUI
 					{
 						//$.unblockUI();
 						$(this).dialog('destroy').remove();
-						self._dialogComponent.status = PsychoJS.Status.FINISHED;
+            
+            // if fullscreen requested, wait for completion of fullscreen transition before proceeding 
+            if (self._psychoJS._window.fullscr) {
+              setTimeout(() => self._dialogComponent.status = PsychoJS.Status.FINISHED, 2000);
+            } else {
+              self._dialogComponent.status = PsychoJS.Status.FINISHED;
+            }
 					}
 
 				})


### PR DESCRIPTION
### See here for a write-up:
- [Slider labels are not aligned correctly Online](https://discourse.psychopy.org/t/slider-labels-are-not-aligned-correctly-online/20397/3)


Other threads mentioning similar issues that may have the same root cause:
- [Inconsistent positions of slider labels](https://discourse.psychopy.org/t/inconsistent-positions-of-slider-labels/19132)
- [Slider Label Position](https://discourse.psychopy.org/t/slider-label-position/19326)
- [Slider on Pavlovia](https://discourse.psychopy.org/t/slider-on-pavlovia/19892)
- [PsychoJS Slider – does not rescale correctly with window size](https://discourse.psychopy.org/t/psychojs-slider-does-not-rescale-correctly-with-window-size/13622)