### PR TITLE
visual/ShapeStim: rotate vertices not sprite

### DIFF
--- a/js/util/Util.js
+++ b/js/util/Util.js
@@ -1094,3 +1094,40 @@ export function sum(inputMaybe = [])
 		// Add up each successive entry starting from naught
 		.reduce(add, 0);
 }
+
+
+/**
+ * Helps rotate a set of x, y coordinates around a certain origin.
+ *
+ * @name module:util.rotatePoint
+ * @function
+ * @public
+ * @param {number} angle - the new angle of rotation in degrees
+ * @param {array} origin - optionally, a new center of rotation
+ * @returns {function(): array} a function to perform the rotation with
+ */
+export function rotatePoint(angle, origin = [0, 0])
+{
+	// Use radians, precalculate as many things as possible
+	const rad = angle * Math.PI / 180;
+	const cos = Math.cos(rad);
+	const sin = Math.sin(rad);
+	const [px = 0, py = 0] = origin;
+
+	/**
+	 * Performs the actual rotation.
+	 *
+	 * @param {array} the coordinates to be transformed
+	 * @returns {array} the new coordinates after rotation
+	 */
+	return ([x1, y1]) =>
+	{
+		const dx = x1 - px;
+		const dy = y1 - py;
+
+		const x2 = (dx * cos) - (dy * sin);
+		const y2 = (dx * sin) + (dy * cos);
+
+		return [x2 + px, y2 + py];
+	}
+}

--- a/js/visual/ShapeStim.js
+++ b/js/visual/ShapeStim.js
@@ -274,7 +274,6 @@ export class ShapeStim extends util.mix(VisualStim).with(ColorMixin, WindowMixin
 
 		// set polygon position and rotation:
 		this._pixi.position = util.to_pixiPoint(this.pos, this.units, this.win);
-		this._pixi.rotation = this.ori * Math.PI / 180.0;
 	}
 
 
@@ -337,10 +336,10 @@ export class ShapeStim extends util.mix(VisualStim).with(ColorMixin, WindowMixin
 		{
 			flip[1] = -1.0;
 		}
-
+		const rotate = rotatePoint(this.ori);
 		// handle size, flipping, and convert to pixel units:
 		this._vertices_px = this._vertices.map(v => util.to_px(
-			[v[0] * this._size[0] * flip[0], v[1] * this._size[1] * flip[1]],
+			rotate([v[0] * this._size[0] * flip[0], v[1] * this._size[1] * flip[1]]),
 			this._units,
 			this._win)
 		);


### PR DESCRIPTION
@apitiot Bring in a point rotate helper in `util.Util` and use that when calculating orientation for `ShapeStim` instances instead of the built-in PIXI method. Potentially, more transformations may be handled in a similar fashion, closes #272 

Demo:
[run.pavlovia.org/thewhodidthis/catch-me-if-you-can &rarr;](https://run.pavlovia.org/thewhodidthis/catch-me-if-you-can)