### PR TITLE
BF: Retain entered text (and placeholder) upon resize

### DIFF
--- a/src/visual/TextBox.js
+++ b/src/visual/TextBox.js
@@ -60,6 +60,12 @@ export class TextBox extends util.mix(VisualStim).with(ColorMixin)
 			this._onChange(true, true)
 		);
 		this._addAttribute(
+			'placeholder',
+			text,
+			'',
+			this._onChange(true, true)
+		);		
+		this._addAttribute(
 			'anchor',
 			anchor,
 			'center',
@@ -404,6 +410,9 @@ export class TextBox extends util.mix(VisualStim).with(ColorMixin)
 			{
 				this._pixi.destroy(true);
 			}
+			// Get the currently entered text
+			let enteredText = this._pixi !== undefined? this._pixi.text: '';
+			// Create new TextInput 
 			this._pixi = new TextInput(this._getTextInputOptions());
 
 			// listeners required for regular textboxes, but may cause problems with button stimuli
@@ -425,7 +434,8 @@ export class TextBox extends util.mix(VisualStim).with(ColorMixin)
 			}
 			if (this._editable)
 			{
-				this._pixi.placeholder = this._text;
+				this.text = enteredText;				
+				this._pixi.placeholder = this._placeholder;
 			}
 			else
 			{


### PR DESCRIPTION
Closes #319 and passes each of the tests below:
* Type something in, resize window -> typed text stays
* Type something in, delete it again -> placeholder reappears
* Type something in, delete it again, resize -> placeholder reappears, and stays when resizing
* Type something in, resize, delete it again -> placeholder reappears
* Type something in, resize, delete it again, resize again -> placeholder reappears
