### PR TITLE
ENH: Improve logging (of errors thrown by PsychoJS)

### DIFF
--- a/src/core/PsychoJS.js
+++ b/src/core/PsychoJS.js
@@ -690,13 +690,12 @@ export class PsychoJS
 		const self = this;
 		window.onerror = function (message, source, lineno, colno, error)
 		{
-			console.error(error);
 			document.body.setAttribute('data-error', JSON.stringify({
 				message: message,
 				source: source,
 				lineno: lineno,
 				colno: colno,
-				error: error.stack
+				error: error
 			}));
 			self._gui.dialog({"error": error});
 			return true;

--- a/src/core/PsychoJS.js
+++ b/src/core/PsychoJS.js
@@ -690,6 +690,7 @@ export class PsychoJS
 		const self = this;
 		window.onerror = function (message, source, lineno, colno, error)
 		{
+			console.error(error);
 			document.body.setAttribute('data-error', JSON.stringify({
 				message: message,
 				source: source,


### PR DESCRIPTION
PsychoJS itself passes information about errors via the error argument (instead of the message argument). This PR ensures that the error argument is logged in full in the data-error attribute of the body, so that it can be picked up by our e2e tests.