### PR TITLE
data/TrialHandler: allow for calling next() like PsychoPy

### DIFF
--- a/src/data/TrialHandler.js
+++ b/src/data/TrialHandler.js
@@ -122,16 +122,12 @@ export class TrialHandler extends PsychObject
 	}
 
 
-	get trialIterator() {
-		return this[Symbol.iterator]();
-	}
-
-
 	/**
 	 * Helps go through each trial in the sequence one by one, mirrors PsychoPy.
 	 */
 	next() {
-		const { value } = this.trialIterator.next();
+		const trialIterator = this[Symbol.iterator]();
+		const { value } = trialIterator.next();
 
 		return value;
 	}

--- a/src/data/TrialHandler.js
+++ b/src/data/TrialHandler.js
@@ -122,6 +122,21 @@ export class TrialHandler extends PsychObject
 	}
 
 
+	get trialIterator() {
+		return this[Symbol.iterator]();
+	}
+
+
+	/**
+	 * Helps go through each trial in the sequence one by one, mirrors PsychoPy.
+	 */
+	next() {
+		const { value } = this.trialIterator.next();
+
+		return value;
+	}
+
+
 	/**
 	 * Iterator over the trial sequence.
 	 *


### PR DESCRIPTION
@apitiot Add a `trialIterator` getter to expose the internal `[Symbol.iterator]()` then made available for step by step calling via `TrialHandler.next()`. Closes #339


Demo:
[pavlovia.org/support/moving-cue &rarr;](https://pavlovia.org/support/moving-cue)