### PR TITLE
DOCS: Add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Have you ever contributed to an Open Source project?
+Your first contribution can be a bit intimidating, but feel free to give it a try. If you get stuck, don't hesitate to ask for help in our [developer forum](https://discourse.psychopy.org/c/dev). This is also a good place to pitch your idea. Next up:
+* **I won't program it myself.** Please file a [GitHub issue](https://github.com/psychopy/psychojs/issues).
+* **I'd like to take a shot.** Read on to find out how!
+
+# How to contribute
+Contributing to PsychoJS consists of four steps:
+1. Getting your own copy
+2. Making your changes
+3. Committing your changes
+4. Submitting a Pull Request
+
+## 1. Getting your own copy of the PsychoJS codebase
+To be sure your improvements can easily be integrated, follow these steps:
+1. **Make a [fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) of the [PsychoJS repo](https://github.com/psychopy/psychojs).** This provides you with your own copy of the PsychoJS source code.
+2. **Inside your fork, make a new [branch](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-branches) for the feature you've got in mind.** Base your new branch on the  *master* branch. We tend to name branches after the feature we're building. For example `olfactory_component`.
+3. **Clone your fork to your hard drive.** Next, switch to the new branch and you're all set up!
+
+## 2. Making your changes
+To help you get started with modifying PsychoJS, we've a couple of [developer guides](https://psychopy.org/online/index.html). To try out your modified PsychoJS, consider [creating and running some tests](https://github.com/psychopy/psychojs_testing).
+
+## 3. Committing your changes
+Once you're happy with your changes, commit them to your GitHub repo. Please use the tags below in your commit and add an informative message.
+  - **BF:** bug fix
+  - **RF:** refactoring
+  - **ENH:** enhancement (such as a new feature)
+  - **DOC:** for all kinds of documentation related commits
+
+## 4. File a Pull Request
+Once you're done, it's time to add it to the central PsychoJS source code. File a [Pull Request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) from your own fork and branch to the *master* branch in the PsychoJS repo. Thanks for contributing!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psychojs",
-  "version": "2021.1.4",
+  "version": "2021.1.dev0",
   "private": true,
   "description": "Helps run in-browser neuroscience, psychology, and psychophysics experiments",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psychojs",
-  "version": "2021.1.dev0",
+  "version": "2021.1.4",
   "private": true,
   "description": "Helps run in-browser neuroscience, psychology, and psychophysics experiments",
   "license": "MIT",


### PR DESCRIPTION
This guide is based on the improvements I made to the [PsychoPy contributing guide](https://github.com/tpronk/psychopy/blob/improve_CONTRIBUTING/CONTRIBUTING.md). There are a couple of differences though:
* We don't have a dev and release branch, so I suggest to base all new branches on master
* Added a reference to our testing repo
* Reduced the number of tags: 
  * Merged BF and FF into BF
  * Merged NF and ENH into ENH
  * Dropped TEST (since all our tests are in a separate repo)