### PR TITLE
Make PsychoJS test-ready again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1708,7 +1708,7 @@
     },
     "node_modules/log4javascript": {
       "version": "1.4.16",
-      "resolved": "git+ssh://git@github.com/tpronk/log4javascript.git#d27efb927c3c47ce9d747263427905d16ded2f2c"
+      "resolved": "git+https://git@github.com/tpronk/log4javascript.git#d27efb927c3c47ce9d747263427905d16ded2f2c"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -3815,7 +3815,7 @@
       "dev": true
     },
     "log4javascript": {
-      "version": "git+ssh://git@github.com/tpronk/log4javascript.git#d27efb927c3c47ce9d747263427905d16ded2f2c",
+      "version": "git+https://git@github.com/tpronk/log4javascript.git#d27efb927c3c47ce9d747263427905d16ded2f2c",
       "from": "log4javascript@github:tpronk/log4javascript"
     },
     "lru-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "psychojs",
-  "version": "2021.x",
+  "version": "2021.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "psychojs",
-      "version": "2021.x",
+      "version": "2021.2.0",
       "license": "MIT",
       "dependencies": {
         "howler": "^2.2.1",
-        "log4javascript": "github:Ritzlgrmft/log4javascript",
+        "log4javascript": "github:tpronk/log4javascript",
         "moment": "^2.29.1",
         "pako": "^1.0.10",
         "pixi.js-legacy": "^6.0.4",
@@ -1708,7 +1708,7 @@
     },
     "node_modules/log4javascript": {
       "version": "1.4.16",
-      "resolved": "git+ssh://git@github.com/Ritzlgrmft/log4javascript.git#d27efb927c3c47ce9d747263427905d16ded2f2c"
+      "resolved": "git+ssh://git@github.com/tpronk/log4javascript.git#d27efb927c3c47ce9d747263427905d16ded2f2c"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -3815,8 +3815,8 @@
       "dev": true
     },
     "log4javascript": {
-      "version": "git+ssh://git@github.com/Ritzlgrmft/log4javascript.git#d27efb927c3c47ce9d747263427905d16ded2f2c",
-      "from": "log4javascript@github:Ritzlgrmft/log4javascript"
+      "version": "git+ssh://git@github.com/tpronk/log4javascript.git#d27efb927c3c47ce9d747263427905d16ded2f2c",
+      "from": "log4javascript@github:tpronk/log4javascript"
     },
     "lru-cache": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "howler": "^2.2.1",
-        "log4javascript": "github:tpronk/log4javascript",
+        "log4javascript": "github:Ritzlgrmft/log4javascript",
         "moment": "^2.29.1",
         "pako": "^1.0.10",
         "pixi.js-legacy": "^6.0.4",
@@ -1708,7 +1708,7 @@
     },
     "node_modules/log4javascript": {
       "version": "1.4.16",
-      "resolved": "git+https://git@github.com/tpronk/log4javascript.git#d27efb927c3c47ce9d747263427905d16ded2f2c"
+      "resolved": "git+https://git@github.com/Ritzlgrmft/log4javascript.git#d27efb927c3c47ce9d747263427905d16ded2f2c"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -3815,8 +3815,8 @@
       "dev": true
     },
     "log4javascript": {
-      "version": "git+https://git@github.com/tpronk/log4javascript.git#d27efb927c3c47ce9d747263427905d16ded2f2c",
-      "from": "log4javascript@github:tpronk/log4javascript"
+      "version": "git+https://git@github.com/Ritzlgrmft/log4javascript.git#d27efb927c3c47ce9d747263427905d16ded2f2c",
+      "from": "log4javascript@github:Ritzlgrmft/log4javascript"
     },
     "lru-cache": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "howler": "^2.2.1",
-    "log4javascript": "github:tpronk/log4javascript",
+    "log4javascript": "github:Ritzlgrmft/log4javascript",
     "moment": "^2.29.1",
     "pako": "^1.0.10",
     "pixi.js-legacy": "^6.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psychojs",
-  "version": "2021.x",
+  "version": "2021.2.0",
   "private": true,
   "description": "Helps run in-browser neuroscience, psychology, and psychophysics experiments",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "howler": "^2.2.1",
-    "log4javascript": "github:Ritzlgrmft/log4javascript",
+    "log4javascript": "github:tpronk/log4javascript",
     "moment": "^2.29.1",
     "pako": "^1.0.10",
     "pixi.js-legacy": "^6.0.4",

--- a/src/core/PsychoJS.js
+++ b/src/core/PsychoJS.js
@@ -743,15 +743,15 @@ export class PsychoJS
 		};
 		window.onunhandledrejection = function (error)
 		{
-			console.error(error.reason);
-			if (error.reason.stack === undefined) {
+			console.error(error?.reason);
+			if (error?.reason?.stack === undefined) {
 				// No stack? Error thrown by PsychoJS; stringify whole error
-				document.body.setAttribute('data-error', JSON.stringify(error.reason));
+				document.body.setAttribute('data-error', JSON.stringify(error?.reason));
 			} else {
 				// Yes stack? Error thrown by JS; stringify stack
-				document.body.setAttribute('data-error', JSON.stringify(error.reason.stack));
+				document.body.setAttribute('data-error', JSON.stringify(error?.reason?.stack));
 			}
-			self._gui.dialog({error: error.reason});
+			self._gui.dialog({error: error?.reason});
 			return true;
 		};
 	}

--- a/src/core/PsychoJS.js
+++ b/src/core/PsychoJS.js
@@ -743,8 +743,15 @@ export class PsychoJS
 		};
 		window.onunhandledrejection = function (error)
 		{
+			//window.myError = error;
+			//console.log(JSON.stringify(error.reason));
 			console.error(error.reason);
-			document.body.setAttribute('data-error', JSON.stringify(error.reason.stack));
+			// No stack? Error thrown by PsychoJS; stringify whole error
+			if (error.reason.stack === undefined) {
+				document.body.setAttribute('data-error', JSON.stringify(error.reason));
+			} else {
+				document.body.setAttribute('data-error', JSON.stringify(error.reason.stack));
+			}
 			self._gui.dialog({error: error.reason});
 			return true;
 		};

--- a/src/core/PsychoJS.js
+++ b/src/core/PsychoJS.js
@@ -744,6 +744,7 @@ export class PsychoJS
 		window.onunhandledrejection = function (error)
 		{
 			console.error(error.reason);
+			document.body.setAttribute('data-error', JSON.stringify(error.reason.stack));
 			self._gui.dialog({error: error.reason});
 			return true;
 		};

--- a/src/core/PsychoJS.js
+++ b/src/core/PsychoJS.js
@@ -743,13 +743,12 @@ export class PsychoJS
 		};
 		window.onunhandledrejection = function (error)
 		{
-			//window.myError = error;
-			//console.log(JSON.stringify(error.reason));
 			console.error(error.reason);
-			// No stack? Error thrown by PsychoJS; stringify whole error
 			if (error.reason.stack === undefined) {
+				// No stack? Error thrown by PsychoJS; stringify whole error
 				document.body.setAttribute('data-error', JSON.stringify(error.reason));
 			} else {
+				// Yes stack? Error thrown by JS; stringify stack
 				document.body.setAttribute('data-error', JSON.stringify(error.reason.stack));
 			}
 			self._gui.dialog({error: error.reason});


### PR DESCRIPTION
This PR contains a number of improvements needed for our automated testing (via GitHub workflows):
- Add version number `2021.2.0` to package.json. Closes #369 
- Log errors captured by `window.onunhandledrejection` into `document.data-error`. Closes #370
- Workaround for [a bug](https://github.com/actions/setup-node/issues/214) in `package-lock.json` files generated by NPM v7. Closes #371