### PR TITLE
package: bring back PreloadJS and import for side effects in core/ServerManager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "psychojs",
       "version": "2021.x",
       "license": "MIT",
       "dependencies": {
@@ -14,7 +13,7 @@
         "moment": "^2.29.1",
         "pako": "^1.0.10",
         "pixi.js-legacy": "^6.0.4",
-        "preload-js": "^0.6.3",
+        "preloadjs": "github:CreateJS/PreloadJS",
         "seedrandom": "^3.0.5",
         "tone": "^14.7.77",
         "xlsx": "^0.17.0"
@@ -1980,10 +1979,10 @@
         "url": "https://opencollective.com/pixijs"
       }
     },
-    "node_modules/preload-js": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/preload-js/-/preload-js-0.6.3.tgz",
-      "integrity": "sha1-3LS3wOGC27ziZ3rU8s+u4uJbTfc="
+    "node_modules/preloadjs": {
+      "version": "1.0.1",
+      "resolved": "git+ssh://git@github.com/CreateJS/PreloadJS.git#eab00cf50fe2f6993c75e04ad7f7e5e9c9e9f083",
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -4037,10 +4036,9 @@
         "pixi.js": "6.0.4"
       }
     },
-    "preload-js": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/preload-js/-/preload-js-0.6.3.tgz",
-      "integrity": "sha1-3LS3wOGC27ziZ3rU8s+u4uJbTfc="
+    "preloadjs": {
+      "version": "git+ssh://git@github.com/CreateJS/PreloadJS.git#eab00cf50fe2f6993c75e04ad7f7e5e9c9e9f083",
+      "from": "preloadjs@github:CreateJS/PreloadJS"
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "moment": "^2.29.1",
     "pako": "^1.0.10",
     "pixi.js-legacy": "^6.0.4",
-    "preload-js": "^0.6.3",
+    "preloadjs": "github:CreateJS/PreloadJS",
     "seedrandom": "^3.0.5",
     "tone": "^14.7.77",
     "xlsx": "^0.17.0"

--- a/src/core/ServerManager.js
+++ b/src/core/ServerManager.js
@@ -7,7 +7,7 @@
  * @license Distributed under the terms of the MIT License
  */
 
-import createjs from 'preload-js';
+import 'preloadjs';
 import { Howl } from 'howler';
 import {PsychoJS} from './PsychoJS';
 import {PsychObject} from '../util/PsychObject';
@@ -1045,7 +1045,7 @@ export class ServerManager extends PsychObject
 				manifest.push(/*new createjs.LoadItem().set(*/{
 					id: name,
 					src: pathStatusData.path,
-					type: createjs.LoadQueue.BINARY, //createjs.Types.BINARY,
+					type: createjs.Types.BINARY,
 					crossOrigin: 'Anonymous'
 				}/*)*/);
 			}


### PR DESCRIPTION
@apitiot @tpronk Restoring `createjs.LoadItem()` calls when pushing to the manifest should work as well now, closes #367