### PR TITLE
BF: Make seedrandom work again

### DIFF
--- a/src/data/TrialHandler.js
+++ b/src/data/TrialHandler.js
@@ -80,12 +80,11 @@ export class TrialHandler extends PsychObject
 		this._addAttribute('nReps', nReps);
 		this._addAttribute('method', method);
 		this._addAttribute('extraInfo', extraInfo);
-		this._addAttribute('seed', seed);
 		this._addAttribute('name', name);
 		this._addAttribute('autoLog', autoLog);
-
+		this.seed = seed;
 		this._prepareTrialList(trialList);
-
+		
 		// number of stimuli
 		this.nStim = this.trialList.length;
 
@@ -257,6 +256,31 @@ export class TrialHandler extends PsychObject
 		return snapshot;
 	}
 
+	/**
+	 * Setter for the seed attribute.
+	 *
+	 * @param {boolean} newSeed - New value for seed
+	 */
+	set seed(newSeed)
+	{
+		this._seed = newSeed;
+		if (this._seed !== undefined) 
+		{
+			this.rng = seedrandom(this._seed);
+		}
+		else
+		{
+			this.rng = seedrandom();
+		}
+	}
+
+	/**
+	 * Getter for the seed attribute.
+	 */
+	get seed()
+	{
+		return this._seed;
+	}
 
 	/**
 	 * Setter for the finished attribute.
@@ -616,16 +640,6 @@ export class TrialHandler extends PsychObject
 		// get an array of the indices of the elements of trialList :
 		const indices = Array.from(this.trialList.keys());
 
-		// seed the random number generator:
-		if (typeof (this.seed) !== 'undefined')
-		{
-			seedrandom(this.seed);
-		}
-		else
-		{
-			seedrandom();
-		}
-
 		if (this.method === TrialHandler.Method.SEQUENTIAL)
 		{
 			this._trialSequence = Array(this.nReps).fill(indices);
@@ -638,7 +652,7 @@ export class TrialHandler extends PsychObject
 			this._trialSequence = [];
 			for (let i = 0; i < this.nReps; ++i)
 			{
-				this._trialSequence.push(util.shuffle(indices.slice()));
+				this._trialSequence.push(util.shuffle(indices.slice(), this.rng));
 			}
 		}
 
@@ -652,7 +666,7 @@ export class TrialHandler extends PsychObject
 			}
 
 			// shuffle the sequence:
-			util.shuffle(flatSequence);
+			util.shuffle(flatSequence, this.rng);
 
 			// reshape it into the trialSequence:
 			this._trialSequence = [];

--- a/src/data/TrialHandler.js
+++ b/src/data/TrialHandler.js
@@ -82,7 +82,7 @@ export class TrialHandler extends PsychObject
 		this._addAttribute('extraInfo', extraInfo);
 		this._addAttribute('name', name);
 		this._addAttribute('autoLog', autoLog);
-		this.seed = seed;
+		this._addAttribute('seed', seed);
 		this._prepareTrialList(trialList);
 		
 		// number of stimuli
@@ -261,7 +261,7 @@ export class TrialHandler extends PsychObject
 	 *
 	 * @param {boolean} newSeed - New value for seed
 	 */
-	set seed(newSeed)
+	setSeed(newSeed)
 	{
 		this._seed = newSeed;
 		if (this._seed !== undefined) 
@@ -272,14 +272,6 @@ export class TrialHandler extends PsychObject
 		{
 			this.rng = seedrandom();
 		}
-	}
-
-	/**
-	 * Getter for the seed attribute.
-	 */
-	get seed()
-	{
-		return this._seed;
 	}
 
 	/**

--- a/src/data/TrialHandler.js
+++ b/src/data/TrialHandler.js
@@ -261,10 +261,10 @@ export class TrialHandler extends PsychObject
 	 *
 	 * @param {boolean} newSeed - New value for seed
 	 */
-	setSeed(newSeed, log)
+	setSeed(seed, log)
 	{
-		this._setAttribute('seed', newSeed, log);
-		if (this.seed !== undefined) 
+		this._setAttribute('seed', seed, log);
+		if (typeof this.seed !== 'undefined') 
 		{
 			this._randomNumberGenerator = seedrandom(this.seed);
 		}

--- a/src/data/TrialHandler.js
+++ b/src/data/TrialHandler.js
@@ -261,16 +261,16 @@ export class TrialHandler extends PsychObject
 	 *
 	 * @param {boolean} newSeed - New value for seed
 	 */
-	setSeed(newSeed)
+	setSeed(newSeed, log)
 	{
-		this._seed = newSeed;
-		if (this._seed !== undefined) 
+		this._setAttribute('seed', newSeed, log);
+		if (this.seed !== undefined) 
 		{
-			this.rng = seedrandom(this._seed);
+			this._randomNumberGenerator = seedrandom(this.seed);
 		}
 		else
 		{
-			this.rng = seedrandom();
+			this._randomNumberGenerator = seedrandom();
 		}
 	}
 
@@ -644,7 +644,7 @@ export class TrialHandler extends PsychObject
 			this._trialSequence = [];
 			for (let i = 0; i < this.nReps; ++i)
 			{
-				this._trialSequence.push(util.shuffle(indices.slice(), this.rng));
+				this._trialSequence.push(util.shuffle(indices.slice(), this._randomNumberGenerator));
 			}
 		}
 
@@ -658,7 +658,7 @@ export class TrialHandler extends PsychObject
 			}
 
 			// shuffle the sequence:
-			util.shuffle(flatSequence, this.rng);
+			util.shuffle(flatSequence, this._randomNumberGenerator);
 
 			// reshape it into the trialSequence:
 			this._trialSequence = [];

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -340,17 +340,17 @@ export function IsPointInsidePolygon(point, vertices)
  * @function
  * @public
  * @param {Object[]} array - the input 1-D array
- * @param {Function} [rng = undefined] - A function used to generated random numbers in the interal [0, 1). Defaults to Math.random
+ * @param {Function} [randomNumberGenerator = undefined] - A function used to generated random numbers in the interal [0, 1). Defaults to Math.random
  * @return {Object[]} the shuffled array
  */
-export function shuffle(array, rng = undefined)
+export function shuffle(array, randomNumberGenerator = undefined)
 {
-	if (rng === undefined) {
-		rng = Math.random;
+	if (randomNumberGenerator === undefined) {
+		randomNumberGenerator = Math.random;
 	}
 	for (let i = array.length - 1; i > 0; i--)
 	{
-		const j = Math.floor(rng() * (i + 1));
+		const j = Math.floor(randomNumberGenerator() * (i + 1));
 		[array[i], array[j]] = [array[j], array[i]];
 	}
 	return array;

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -340,13 +340,17 @@ export function IsPointInsidePolygon(point, vertices)
  * @function
  * @public
  * @param {Object[]} array - the input 1-D array
+ * @param {Function} [rng = undefined] - A function used to generated random numbers in the interal [0, 1). Defaults to Math.random
  * @return {Object[]} the shuffled array
  */
-export function shuffle(array)
+export function shuffle(array, rng = undefined)
 {
+	if (rng === undefined) {
+		rng = Math.random;
+	}
 	for (let i = array.length - 1; i > 0; i--)
 	{
-		const j = Math.floor(Math.random() * (i + 1));
+		const j = Math.floor(rng() * (i + 1));
 		[array[i], array[j]] = [array[j], array[i]];
 	}
 	return array;


### PR DESCRIPTION
This bug-fix consists of modifications to util.shuffle and TrialHandler:
1. `util.shuffle` supports an optional second argument, rng, which defaults to Math.random
2. TrialHandler now has a getter and setter for the seed attrbute. On setting this attribute it constructs a random number generator (rng) using seedrandom and the seed provided. This rng is passed to `util.shuffle` when preparing a sequence with method RANDOM or FULL_RANDOM

The tests of these modifications can be found in: https://github.com/psychopy/psychojs_testing/blob/main/tests/karma_randomization/karma_randomization.js