### PR TITLE
added a getter for finished in TrialHandler

### DIFF
--- a/src/data/TrialHandler.js
+++ b/src/data/TrialHandler.js
@@ -306,6 +306,17 @@ export class TrialHandler extends PsychObject
 
 
 	/**
+	 * Getter for the finished attribute.
+	 *
+	 * @returns {boolean} whether or not the trial has finished.
+	 */
+	get finished()
+	{
+		return this._finished;
+	}
+
+
+	/**
 	 * Setter for the finished attribute.
 	 *
 	 * @param {boolean} isFinished - whether or not the loop is finished.


### PR DESCRIPTION
finished is a property of the snapshot, which corresponds to _finished at the TrialHandler level, hence the need of a getter now that the code generator uses TrialHandler.fromSnapshot, to restore the internal state