### PR TITLE
BF: remove onunhandledrejection but keep data-error

### DIFF
--- a/src/core/PsychoJS.js
+++ b/src/core/PsychoJS.js
@@ -728,7 +728,7 @@ export class PsychoJS
 		window.onerror = function (message, source, lineno, colno, error)
 		{
 			console.error(error);
-
+			// Log errors in data-error, for processing by WebDriverIO tests
 			document.body.setAttribute('data-error', JSON.stringify({
 				message: message,
 				source: source,
@@ -736,22 +736,7 @@ export class PsychoJS
 				colno: colno,
 				error: error
 			}));
-      
 			self._gui.dialog({"error": error});
-      
-			return true;
-		};
-		window.onunhandledrejection = function (error)
-		{
-			console.error(error?.reason);
-			if (error?.reason?.stack === undefined) {
-				// No stack? Error thrown by PsychoJS; stringify whole error
-				document.body.setAttribute('data-error', JSON.stringify(error?.reason));
-			} else {
-				// Yes stack? Error thrown by JS; stringify stack
-				document.body.setAttribute('data-error', JSON.stringify(error?.reason?.stack));
-			}
-			self._gui.dialog({error: error?.reason});
 			return true;
 		};
 	}


### PR DESCRIPTION
This is an alternative to PR #398, which keeps in the `data-error` part in `window.onerror`, which is useful for our automated testing. As @thewhodidthis did in his PR, I removed the `window.onunhandledrejection`, but I'd like to check with @apitiot whether this might not cause other issues?