### PR TITLE
getSnapshot / fromSnapshot now also store/restore TrialHandler's trial attributes

### DIFF
--- a/src/data/TrialHandler.js
+++ b/src/data/TrialHandler.js
@@ -222,6 +222,7 @@ export class TrialHandler extends PsychObject
 	 * @property {number} thisIndex - the index of the current trial in the conditions list
 	 * @property {number} ran - whether or not the trial ran
 	 * @property {number} finished - whether or not the trials finished
+	 * @property {Object} trialAttributes - a list of trial attributes
 	 */
 	/**
 	 * Get a snapshot of the current internal state of the trial handler (e.g. current trial number,
@@ -255,6 +256,26 @@ export class TrialHandler extends PsychObject
 			addData: (key, value) => this.addData(key, value)
 		};
 
+		// add to the snapshots the current trial's attributes:
+		const currentTrial = this.getCurrentTrial();
+		const excludedAttributes = ['handler', 'name', 'nStim', 'nRemaining', 'thisRepN', 'thisTrialN', 'thisN', 'thisIndex', 'ran', 'finished'];
+		const trialAttributes = [];
+		for (const attribute in currentTrial)
+		{
+			if (!(attribute in excludedAttributes))
+			{
+				snapshot[attribute] = currentTrial[attribute];
+				trialAttributes.push(attribute);
+			}
+			else
+			{
+				this._psychoJS.logger.warn(`attempt to replace the value of protected TrialHandler variable: ${attribute}`);
+			}
+			snapshot.trialAttributes = trialAttributes;
+		}
+
+
+
 		this._snapshots.push(snapshot);
 
 		return snapshot;
@@ -278,6 +299,7 @@ export class TrialHandler extends PsychObject
 		}
 	}
 
+	
 	/**
 	 * Set the internal state of this trial handler from the given snapshot.
 	 *
@@ -304,6 +326,12 @@ export class TrialHandler extends PsychObject
 		snapshot.handler._finished = snapshot._finished;
 
 		snapshot.handler.thisTrial = snapshot.handler.getCurrentTrial();
+
+		// add to the trial handler the snapshot's trial attributes:
+		for (const attribute of snapshot.trialAttributes)
+		{
+			snapshot.handler[attribute] = snapshot[attribute];
+		}
 	}
 
 

--- a/src/util/PsychObject.js
+++ b/src/util/PsychObject.js
@@ -120,7 +120,10 @@ export class PsychObject extends EventEmitter
 	 */
 	_setAttribute(attributeName, attributeValue, log = false, operation = undefined, stealth = false)
 	{
-		const response = {origin: 'PsychObject.setAttribute', context: 'when setting the attribute of an object'};
+		const response = {
+			origin: 'PsychObject.setAttribute',
+			context: 'when setting the attribute of an object'
+		};
 
 		if (typeof attributeName == 'undefined')
 		{


### PR DESCRIPTION
This makes it possible to access those attributes directly from the TrialHandler, like in PsychoPy:

loop = new TrialHandler({ [...] });
[...]
const color = loop['color'];