### PR TITLE
css: override ui-dialog inline styles, use percentage height on body

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,11 @@
+html {
+  height: 100%;
+}
+
 body {
   align-items: center;
   display: flex;
-  height: 100vh;
+  height: 100%;
   justify-content: center;
   margin: 0;
 }
@@ -53,9 +57,11 @@ a:hover {
 }
 
 .ui-dialog {
+  left: auto !important;
   margin: auto;
   max-width: 88vw;
   position: relative;
+  top: auto !important;
 }
 
 /* Don't display close button in the top right corner of the box */


### PR DESCRIPTION
@tpronk @apitiot @RebeccaHirst Closes #435 

<img width="1552" alt="Screenshot 2021-07-15 at 19 47 01" src="https://user-images.githubusercontent.com/167995/125841442-9e0ddda2-6c7a-40ef-9e99-3487ec06b615.png">

<img width="1552" alt="Screenshot 2021-07-15 at 19 47 47" src="https://user-images.githubusercontent.com/167995/125841451-24494bab-49fa-4dcc-8944-d70e31650dad.png">