### PR TITLE
BF: Check for empty string in `completionUrl`/`cancellationUrl` before redirecting

### DIFF
--- a/src/core/PsychoJS.js
+++ b/src/core/PsychoJS.js
@@ -534,12 +534,12 @@ export class PsychoJS
 					// return from fullscreen if we were there:
 					this._window.closeFullScreen();
 
-					// redirect if redirection URLs have been provided:
-					if (isCompleted && typeof self._completionUrl !== "undefined" && self._completionUrl)
+					// redirect if redirection URLs have been provided (and not empty):
+					if (isCompleted && self._completionUrl)
 					{
 						window.location = self._completionUrl;
 					}
-					else if (!isCompleted && typeof self._cancellationUrl !== "undefined" && self._cancellationUrl)
+					else if (!isCompleted && self._cancellationUrl)
 					{
 						window.location = self._cancellationUrl;
 					}

--- a/src/core/PsychoJS.js
+++ b/src/core/PsychoJS.js
@@ -535,11 +535,11 @@ export class PsychoJS
 					this._window.closeFullScreen();
 
 					// redirect if redirection URLs have been provided:
-					if (isCompleted && typeof self._completionUrl !== "undefined")
+					if (isCompleted && typeof self._completionUrl !== "undefined" && self._completionUrl)
 					{
 						window.location = self._completionUrl;
 					}
-					else if (!isCompleted && typeof self._cancellationUrl !== "undefined")
+					else if (!isCompleted && typeof self._cancellationUrl !== "undefined" && self._cancellationUrl)
 					{
 						window.location = self._cancellationUrl;
 					}


### PR DESCRIPTION
Don't redirect if `completionUrl`/`cancellationUrl` is an empty string.

In PsychoPy, if one of the `completionUrl`/`cancellationUrl` fields are left empty, the empty field is exported as an empty string. For example, if `cancellationUrl` is not set, you get:

`    psychoJS.setRedirectUrls('example.com', '');`

And then PsychoJS will set `window.location = ''` which will reload the current page and restart the experiment.

You would expect an `empty string` URL to do nothing, for example, if  a `cancellationUrl` in was not set in PsychoPy, it is probably the user's intention to handle the cancellation themselves and not necessarily reload the page and restart the experiment.