### PR TITLE
NF: Add `util.randchoice` to mirror Python

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -370,8 +370,12 @@ export function shuffle(array, randomNumberGenerator = undefined)
  */
 export function randchoice(array, randomNumberGenerator = undefined)
 {
-	let shuffledArray = shuffle(array, randomNumberGenerator=randomNumberGenerator)
-	return shuffledArray.slice((- 1))[0];
+	if (randomNumberGenerator === undefined)
+	{
+		randomNumberGenerator = Math.random;
+	}
+	const j = Math.floor(randomNumberGenerator() * array.length);
+	return array[j]
 }
 
 /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -359,6 +359,22 @@ export function shuffle(array, randomNumberGenerator = undefined)
 }
 
 /**
+ * Pick a random value from an array, uses `util.shuffle` to shuffle the array and returns the last value.
+ *
+ * @name module:util.randchoice
+ * @function
+ * @public
+ * @param {Object[]} array - the input 1-D array
+ * @param {Function} [randomNumberGenerator = undefined] - A function used to generated random numbers in the interal [0, 1). Defaults to Math.random
+ * @return {Object[]} a chosen value from the array
+ */
+export function randchoice(array, randomNumberGenerator = undefined)
+{
+	let shuffledArray = shuffle(array, randomNumberGenerator=randomNumberGenerator)
+	return shuffledArray.slice((- 1))[0];
+}
+
+/**
  * Get the position of the object, in pixel units
  *
  * @name module:util.getPositionFromObject


### PR DESCRIPTION
In Python, we import `numpy.random.choice` as `randchoice`, so this adds an equivalent function to the JS side.

I can then add an alias to the transpiler to replace `randchoice` with `util.randchoice` in Code components :) 