### PR TITLE
BF: _pixi.rotation should be set to -this._ori to match PsychoPy (clock) ori

### DIFF
--- a/src/visual/FaceDetector.js
+++ b/src/visual/FaceDetector.js
@@ -282,7 +282,7 @@ export class FaceDetector extends VisualStim
 		this._pixi.scale.x = 1;
 		this._pixi.scale.y = -1;
 
-		this._pixi.rotation = this.ori * Math.PI / 180;
+		this._pixi.rotation = -this.ori * Math.PI / 180;
 		this._pixi.position = to_pixiPoint(this.pos, this.units, this.win);
 
 		this._pixi.alpha = this._opacity;

--- a/src/visual/ImageStim.js
+++ b/src/visual/ImageStim.js
@@ -312,7 +312,7 @@ export class ImageStim extends util.mix(VisualStim).with(ColorMixin)
 
 		// set the position, rotation, and anchor (image centered on pos):
 		this._pixi.position = to_pixiPoint(this.pos, this.units, this.win);
-		this._pixi.rotation = this.ori * Math.PI / 180;
+		this._pixi.rotation = -this.ori * Math.PI / 180;
 		this._pixi.anchor.x = 0.5;
 		this._pixi.anchor.y = 0.5;
 

--- a/src/visual/MovieStim.js
+++ b/src/visual/MovieStim.js
@@ -401,7 +401,7 @@ export class MovieStim extends VisualStim
 
 		// set the position, rotation, and anchor (movie centered on pos):
 		this._pixi.position = to_pixiPoint(this.pos, this.units, this.win);
-		this._pixi.rotation = this.ori * Math.PI / 180;
+		this._pixi.rotation = -this.ori * Math.PI / 180;
 		this._pixi.anchor.x = 0.5;
 		this._pixi.anchor.y = 0.5;
 

--- a/src/visual/ShapeStim.js
+++ b/src/visual/ShapeStim.js
@@ -260,7 +260,7 @@ export class ShapeStim extends util.mix(VisualStim).with(ColorMixin, WindowMixin
 
 		// set polygon position and rotation:
 		this._pixi.position = to_pixiPoint(this.pos, this.units, this.win);
-		this._pixi.rotation = this.ori * Math.PI / 180.0;
+		this._pixi.rotation = -this.ori * Math.PI / 180.0;
 	}
 
 	/**

--- a/src/visual/Slider.js
+++ b/src/visual/Slider.js
@@ -668,7 +668,7 @@ export class Slider extends util.mix(VisualStim).with(ColorMixin, WindowMixin)
 		this._pixi.scale.x = 1;
 		this._pixi.scale.y = -1;
 
-		this._pixi.rotation = this._ori * Math.PI / 180;
+		this._pixi.rotation = -this._ori * Math.PI / 180;
 		this._pixi.position = this._getPosition_px();
 
 		this._pixi.alpha = this._opacity;
@@ -1095,7 +1095,7 @@ export class Slider extends util.mix(VisualStim).with(ColorMixin, WindowMixin)
 			const labelText = new PIXI.Text(this._labels[l], labelTextStyle);
 			labelText.position.x = this._labelPositions_px[l][0];
 			labelText.position.y = this._labelPositions_px[l][1];
-			labelText.rotation = (this._ori + this._labelOri) * Math.PI / 180;
+			labelText.rotation = -(this._ori + this._labelOri) * Math.PI / 180;
 			labelText.anchor = this._labelAnchor;
 			labelText.alpha = 1;
 

--- a/src/visual/TextBox.js
+++ b/src/visual/TextBox.js
@@ -485,7 +485,7 @@ export class TextBox extends util.mix(VisualStim).with(ColorMixin)
 
 		this._pixi.scale.x = this._flipHoriz ? -1 : 1;
 		this._pixi.scale.y = this._flipVert ? 1 : -1;
-		this._pixi.rotation = this._ori * Math.PI / 180;
+		this._pixi.rotation = -this._ori * Math.PI / 180;
 		[this._pixi.x, this._pixi.y] = util.to_px(this._pos, this._units, this._win);
 
 		this._pixi.alpha = this._opacity;

--- a/src/visual/TextStim.js
+++ b/src/visual/TextStim.js
@@ -324,7 +324,7 @@ export class TextStim extends util.mix(VisualStim).with(ColorMixin)
 		this._pixi.scale.x = this._flipHoriz ? -1 : 1;
 		this._pixi.scale.y = this._flipVert ? 1 : -1;
 
-		this._pixi.rotation = this._ori * Math.PI / 180;
+		this._pixi.rotation = -this._ori * Math.PI / 180;
 		this._pixi.position = to_pixiPoint(this.pos, this.units, this.win);
 
 		this._pixi.alpha = this._opacity;


### PR DESCRIPTION
In PsychoPy @peircej chose to use clock/compass convention for ori rather than
engineering/maths convention, so +ve changes move clockwise not anti.

A previous change ( f12ccafff3 ) to the setOri function doesn't appear to have any
effect on the stimuli using the current rendering method