### PR TITLE
BF issue with projectId field when saving to database

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psychojs",
-  "version": "2022.1.1",
+  "version": "2022.1.3",
   "private": true,
   "description": "Helps run in-browser neuroscience, psychology, and psychophysics experiments",
   "license": "MIT",

--- a/src/core/PsychoJS.js
+++ b/src/core/PsychoJS.js
@@ -18,7 +18,6 @@ import { GUI } from "./GUI.js";
 import { Logger } from "./Logger.js";
 import { ServerManager } from "./ServerManager.js";
 import { Window } from "./Window.js";
-// import {Shelf} from "../data/Shelf";
 
 /**
  * <p>PsychoJS manages the lifecycle of an experiment. It initialises the PsychoJS library and its various components (e.g. the {@link ServerManager}, the {@link EventManager}), and is used by the experiment to schedule the various tasks.</p>
@@ -109,11 +108,6 @@ export class PsychoJS
 		return this._browser;
 	}
 
-	// get shelf()
-	// {
-	// 	return this._shelf;
-	// }
-
 	/**
 	 * @constructor
 	 * @public
@@ -157,9 +151,6 @@ export class PsychoJS
 
 		// Window:
 		this._window = undefined;
-
-		// // Shelf:
-		// this._shelf = new Shelf(this);
 
 		// redirection URLs:
 		this._cancellationUrl = undefined;

--- a/src/data/ExperimentHandler.js
+++ b/src/data/ExperimentHandler.js
@@ -338,14 +338,14 @@ export class ExperimentHandler extends PsychObject
 		else if (this._psychoJS.config.experiment.saveFormat === ExperimentHandler.SaveFormat.DATABASE)
 		{
 			const gitlabConfig = this._psychoJS.config.gitlab;
-			const projectId = (typeof gitlabConfig !== "undefined" && typeof gitlabConfig.projectId !== "undefined") ? gitlabConfig.projectId : undefined;
+			const __projectId = (typeof gitlabConfig !== "undefined" && typeof gitlabConfig.projectId !== "undefined") ? gitlabConfig.projectId : undefined;
 
 			let documents = [];
 
 			for (let r = 0; r < data.length; r++)
 			{
 				let doc = {
-					projectId,
+					__projectId,
 					__experimentName: this._experimentName,
 					__participant: this._participant,
 					__session: this._session,

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -2,4 +2,3 @@ export * from "./ExperimentHandler.js";
 export * from "./TrialHandler.js";
 export * from "./QuestHandler.js";
 export * from "./MultiStairHandler.js";
-//export * from "./Shelf.js";


### PR DESCRIPTION
An underscore was inadvertently removed from _projectId. It's now back.