### PR TITLE
Coloring for image based gratings

### DIFF
--- a/src/visual/GratingStim.js
+++ b/src/visual/GratingStim.js
@@ -67,6 +67,7 @@ export class GratingStim extends VisualStim
 	 * @property {Object} imageShader.uniforms - default uniforms for the image based shader.
 	 * @property {float} imageShader.uniforms.uFreq=1.0 - how much times image repeated within grating stimuli.
 	 * @property {float} imageShader.uniforms.uPhase=0.0 - offset of the image along X axis.
+	 * @property {float} imageShader.uniforms.uAlpha=1.0 - value of the alpha channel.
 	 *
 	 * @property {Object} sin - Creates 2d sine wave image as if 1d sine graph was extended across Z axis and observed from above.
 	 * {@link https://en.wikipedia.org/wiki/Sine_wave}
@@ -74,6 +75,7 @@ export class GratingStim extends VisualStim
 	 * @property {Object} sin.uniforms - default uniforms for sine wave shader
 	 * @property {float} sin.uniforms.uFreq=1.0 - frequency of sine wave.
 	 * @property {float} sin.uniforms.uPhase=0.0 - phase of sine wave.
+	 * @property {float} sin.uniforms.uAlpha=1.0 - value of the alpha channel.
 	 *
 	 * @property {Object} sqr - Creates 2d square wave image as if 1d square graph was extended across Z axis and observed from above.
 	 * {@link https://en.wikipedia.org/wiki/Square_wave}
@@ -81,6 +83,7 @@ export class GratingStim extends VisualStim
 	 * @property {Object} sqr.uniforms - default uniforms for square wave shader
 	 * @property {float} sqr.uniforms.uFreq=1.0 - frequency of square wave.
 	 * @property {float} sqr.uniforms.uPhase=0.0 - phase of square wave.
+	 * @property {float} sqr.uniforms.uAlpha=1.0 - value of the alpha channel.
 	 *
 	 * @property {Object} saw - Creates 2d sawtooth wave image as if 1d sawtooth graph was extended across Z axis and observed from above.
 	 * {@link https://en.wikipedia.org/wiki/Sawtooth_wave}
@@ -88,6 +91,7 @@ export class GratingStim extends VisualStim
 	 * @property {Object} saw.uniforms - default uniforms for sawtooth wave shader
 	 * @property {float} saw.uniforms.uFreq=1.0 - frequency of sawtooth wave.
 	 * @property {float} saw.uniforms.uPhase=0.0 - phase of sawtooth wave.
+	 * @property {float} saw.uniforms.uAlpha=1.0 - value of the alpha channel.
 	 *
 	 * @property {Object} tri - Creates 2d triangle wave image as if 1d triangle graph was extended across Z axis and observed from above.
 	 * {@link https://en.wikipedia.org/wiki/Triangle_wave}
@@ -96,6 +100,7 @@ export class GratingStim extends VisualStim
 	 * @property {float} tri.uniforms.uFreq=1.0 - frequency of triangle wave.
 	 * @property {float} tri.uniforms.uPhase=0.0 - phase of triangle wave.
 	 * @property {float} tri.uniforms.uPeriod=1.0 - period of triangle wave.
+	 * @property {float} tri.uniforms.uAlpha=1.0 - value of the alpha channel.
 	 *
 	 * @property {Object} sinXsin - Creates an image of two 2d sine waves multiplied with each other.
 	 * {@link https://en.wikipedia.org/wiki/Sine_wave}
@@ -103,6 +108,7 @@ export class GratingStim extends VisualStim
 	 * @property {Object} sinXsin.uniforms - default uniforms for shader
 	 * @property {float} sinXsin.uniforms.uFreq=1.0 - frequency of sine wave (both of them).
 	 * @property {float} sinXsin.uniforms.uPhase=0.0 - phase of sine wave (both of them).
+	 * @property {float} sinXsin.uniforms.uAlpha=1.0 - value of the alpha channel.
 	 *
 	 * @property {Object} sqrXsqr - Creates an image of two 2d square waves multiplied with each other.
 	 * {@link https://en.wikipedia.org/wiki/Square_wave}
@@ -110,12 +116,14 @@ export class GratingStim extends VisualStim
 	 * @property {Object} sqrXsqr.uniforms - default uniforms for shader
 	 * @property {float} sqrXsqr.uniforms.uFreq=1.0 - frequency of sine wave (both of them).
 	 * @property {float} sqrXsqr.uniforms.uPhase=0.0 - phase of sine wave (both of them).
+	 * @property {float} sqrXsqr.uniforms.uAlpha=1.0 - value of the alpha channel.
 	 *
 	 * @property {Object} circle - Creates a filled circle shape with sharp edges.
 	 * @property {String} circle.shader - shader source code for filled circle.
 	 * @property {Object} circle.uniforms - default uniforms for shader.
 	 * @property {float} circle.uniforms.uRadius=1.0 - Radius of the circle. Ranges [0.0, 1.0], where 0.0 is circle so tiny it results in empty stim
 	 * and 1.0 is circle that spans from edge to edge of the stim.
+	 * @property {float} circle.uniforms.uAlpha=1.0 - value of the alpha channel.
 	 *
 	 * @property {Object} gauss - Creates a 2d Gaussian image as if 1d Gaussian graph was rotated arount Y axis and observed from above.
 	 * {@link https://en.wikipedia.org/wiki/Gaussian_function}
@@ -124,18 +132,21 @@ export class GratingStim extends VisualStim
 	 * @property {float} gauss.uniforms.uA=1.0 - A constant for gaussian formula (see link).
 	 * @property {float} gauss.uniforms.uB=0.0 - B constant for gaussian formula (see link).
 	 * @property {float} gauss.uniforms.uC=0.16 - C constant for gaussian formula (see link).
+	 * @property {float} gauss.uniforms.uAlpha=1.0 - value of the alpha channel.
 	 *
 	 * @property {Object} cross - Creates a filled cross shape with sharp edges.
 	 * @property {String} cross.shader - shader source code for cross shader
 	 * @property {Object} cross.uniforms - default uniforms for shader
 	 * @property {float} cross.uniforms.uThickness=0.2 - Thickness of the cross. Ranges [0.0, 1.0], where 0.0 thickness makes a cross so thin it becomes
 	 * invisible and results in an empty stim and 1.0 makes it so thick it fills the entire stim.
+	 * @property {float} cross.uniforms.uAlpha=1.0 - value of the alpha channel.
 	 *
 	 * @property {Object} radRamp - Creates 2d radial ramp image.
 	 * @property {String} radRamp.shader - shader source code for radial ramp shader
 	 * @property {Object} radRamp.uniforms - default uniforms for shader
 	 * @property {float} radRamp.uniforms.uSqueeze=1.0 - coefficient that helps to modify size of the ramp. Ranges [0.0, Infinity], where 0.0 results in ramp being so large
 	 * it fills the entire stim and Infinity makes it so tiny it's invisible.
+	 * @property {float} radRamp.uniforms.uAlpha=1.0 - value of the alpha channel.
 	 *
 	 * @property {Object} raisedCos - Creates 2d raised-cosine image as if 1d raised-cosine graph was rotated around Y axis and observed from above.
 	 * {@link https://en.wikipedia.org/wiki/Raised-cosine_filter}
@@ -143,6 +154,7 @@ export class GratingStim extends VisualStim
 	 * @property {Object} raisedCos.uniforms - default uniforms for shader
 	 * @property {float} raisedCos.uniforms.uBeta=0.25 - roll-off factor (see link).
 	 * @property {float} raisedCos.uniforms.uPeriod=0.625 - reciprocal of the symbol-rate (see link).
+	 * @property {float} raisedCos.uniforms.uAlpha=1.0 - value of the alpha channel.
 	 */
 	static #SHADERS = {
 		imageShader: {
@@ -639,11 +651,10 @@ export class GratingStim extends VisualStim
 	 */ 
 	setInterpolate (interpolate = false, log = false) {
 		this._setAttribute("interpolate", interpolate, log);
-		if (this._pixi === undefined || !this._pixi.shader.uniforms.uTex) {
-			return;
+		if (this._pixi instanceof PIXI.Mesh && this._pixi.shader.uniforms.uTex instanceof PIXI.Texture) {
+			this._pixi.shader.uniforms.uTex.baseTexture.scaleMode = interpolate ? PIXI.SCALE_MODES.LINEAR : PIXI.SCALE_MODES.NEAREST;
+			this._pixi.shader.uniforms.uTex.baseTexture.update();
 		}
-		this._pixi.shader.uniforms.uTex.baseTexture.scaleMode = interpolate ? PIXI.SCALE_MODES.LINEAR : PIXI.SCALE_MODES.NEAREST;
-		this._pixi.shader.uniforms.uTex.baseTexture.update();
 	}
 
 	/**

--- a/src/visual/shaders/circleShader.frag
+++ b/src/visual/shaders/circleShader.frag
@@ -17,11 +17,12 @@ out vec4 shaderOut;
 #define M_PI 3.14159265358979
 uniform float uRadius;
 uniform vec3 uColor;
+uniform float uAlpha;
 
 void main() {
     vec2 uv = vUvs;
     // converting first to [-1, 1] space to get the proper color functionality
     // then back to [0, 1]
     float s = (1. - step(uRadius, length(uv * 2. - 1.))) * 2. - 1.;
-    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0);
+    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0) * uAlpha;
 }

--- a/src/visual/shaders/crossShader.frag
+++ b/src/visual/shaders/crossShader.frag
@@ -17,6 +17,7 @@ out vec4 shaderOut;
 #define M_PI 3.14159265358979
 uniform float uThickness;
 uniform vec3 uColor;
+uniform float uAlpha;
 
 void main() {
     vec2 uv = vUvs;
@@ -25,5 +26,5 @@ void main() {
     // converting first to [-1, 1] space to get the proper color functionality
     // then back to [0, 1]
     float s = (1. - sx * sy) * 2. - 1.;
-    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0);
+    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0) * uAlpha;
 }

--- a/src/visual/shaders/imageShader.frag
+++ b/src/visual/shaders/imageShader.frag
@@ -1,11 +1,10 @@
 /**
- * Gaussian Function.
- * https://en.wikipedia.org/wiki/Gaussian_function
+ * Image shader.
  *
  * @author Nikita Agafonov
  * @copyright (c) 2020-2022 Open Science Tools Ltd. (https://opensciencetools.org)
  * @license Distributed under the terms of the MIT License
- * @description Creates a 2d Gaussian image as if 1d Gaussian graph was rotated arount Y axis and observed from above.
+ * @description Renders passed in image with applied effects.
  * @usedby GratingStim.js
  */
 
@@ -15,20 +14,18 @@ precision mediump float;
 in vec2 vUvs;
 out vec4 shaderOut;
 
-uniform float uA;
-uniform float uB;
-uniform float uC;
+#define M_PI 3.14159265358979
+uniform sampler2D uTex;
+uniform float uFreq;
+uniform float uPhase;
 uniform vec3 uColor;
 uniform float uAlpha;
 
-#define M_PI 3.14159265358979
-
 void main() {
     vec2 uv = vUvs;
-    float c2 = uC * uC;
-    float x = length(uv - .5);
     // converting first to [-1, 1] space to get the proper color functionality
     // then back to [0, 1]
-    float g = uA * exp(-pow(x - uB, 2.) / c2 * .5) * 2. - 1.;
-    shaderOut = vec4(vec3(g) * uColor * .5 + .5, 1.) * uAlpha;
+    vec4 s = texture(uTex, vec2(uv.x * uFreq + uPhase, uv.y));
+    s.xyz = s.xyz * 2. - 1.;
+    shaderOut = vec4(s.xyz * uColor * .5 + .5, s.a) * uAlpha;
 }

--- a/src/visual/shaders/radRampShader.frag
+++ b/src/visual/shaders/radRampShader.frag
@@ -15,6 +15,7 @@ in vec2 vUvs;
 out vec4 shaderOut;
 uniform float uSqueeze;
 uniform vec3 uColor;
+uniform float uAlpha;
 
 #define M_PI 3.14159265358979
 
@@ -23,5 +24,5 @@ void main() {
     // converting first to [-1, 1] space to get the proper color functionality
     // then back to [0, 1]
     float s = (1. - length(uv * 2. - 1.) * uSqueeze) * 2. - 1.;
-    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0);
+    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0) * uAlpha;
 }

--- a/src/visual/shaders/raisedCosShader.frag
+++ b/src/visual/shaders/raisedCosShader.frag
@@ -19,6 +19,7 @@ out vec4 shaderOut;
 uniform float uBeta;
 uniform float uPeriod;
 uniform vec3 uColor;
+uniform float uAlpha;
 
 void main() {
     vec2 uv = vUvs;
@@ -35,5 +36,5 @@ void main() {
     // converting first to [-1, 1] space to get the proper color functionality
     // then back to [0, 1]
     s = s * 2. - 1.;
-    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0);
+    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0) * uAlpha;
 }

--- a/src/visual/shaders/sawShader.frag
+++ b/src/visual/shaders/sawShader.frag
@@ -19,6 +19,7 @@ out vec4 shaderOut;
 uniform float uFreq;
 uniform float uPhase;
 uniform vec3 uColor;
+uniform float uAlpha;
 
 void main() {
     vec2 uv = vUvs;
@@ -26,5 +27,5 @@ void main() {
     // converting first to [-1, 1] space to get the proper color functionality
     // then back to [0, 1]
     s = mod(s, 1.) * 2. - 1.;
-    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0);
+    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0) * uAlpha;
 }

--- a/src/visual/shaders/sinShader.frag
+++ b/src/visual/shaders/sinShader.frag
@@ -19,10 +19,11 @@ out vec4 shaderOut;
 uniform float uFreq;
 uniform float uPhase;
 uniform vec3 uColor;
+uniform float uAlpha;
 
 void main() {
-    vec2 uv = vUvs;
+    vec2 uv = vUvs - .25;
     float s = sin((uFreq * uv.x + uPhase) * 2. * M_PI);
-    // it's important to convert to [0, 1] while multiplication to uColor, not before, to preserve desired coloring functionality
-    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0);
+    // it's important to convert to [0, 1] while multiplying to uColor, not before, to preserve desired coloring functionality
+    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0) * uAlpha;
 }

--- a/src/visual/shaders/sinXsinShader.frag
+++ b/src/visual/shaders/sinXsinShader.frag
@@ -20,12 +20,13 @@ out vec4 shaderOut;
 uniform float uFreq;
 uniform float uPhase;
 uniform vec3 uColor;
+uniform float uAlpha;
 
 void main() {
-    vec2 uv = vUvs;
+    vec2 uv = vec2(vUvs.x - .25, vUvs.y * -1. - .25);
     float sx = sin((uFreq * uv.x + uPhase) * PI2);
     float sy = sin((uFreq * uv.y + uPhase) * PI2);
     float s = sx * sy;
-    // it's important to convert to [0, 1] while multiplication to uColor, not before, to preserve desired coloring functionality
-    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0);
+    // it's important to convert to [0, 1] while multiplying to uColor, not before, to preserve desired coloring functionality
+    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0) * uAlpha;
 }

--- a/src/visual/shaders/sqrShader.frag
+++ b/src/visual/shaders/sqrShader.frag
@@ -19,10 +19,11 @@ out vec4 shaderOut;
 uniform float uFreq;
 uniform float uPhase;
 uniform vec3 uColor;
+uniform float uAlpha;
 
 void main() {
-    vec2 uv = vUvs;
+    vec2 uv = vUvs - .25;
     float s = sign(sin((uFreq * uv.x + uPhase) * 2. * M_PI));
-    // it's important to convert to [0, 1] while multiplication to uColor, not before, to preserve desired coloring functionality
-    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0);
+    // it's important to convert to [0, 1] while multiplying to uColor, not before, to preserve desired coloring functionality
+    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0) * uAlpha;
 }

--- a/src/visual/shaders/sqrXsqrShader.frag
+++ b/src/visual/shaders/sqrXsqrShader.frag
@@ -20,12 +20,13 @@ out vec4 shaderOut;
 uniform float uFreq;
 uniform float uPhase;
 uniform vec3 uColor;
+uniform float uAlpha;
 
 void main() {
-    vec2 uv = vUvs;
+    vec2 uv = vec2(vUvs.x - .25, vUvs.y * -1. - .25);
     float sx = sign(sin((uFreq * uv.x + uPhase) * PI2));
     float sy = sign(sin((uFreq * uv.y + uPhase) * PI2));
     float s = sx * sy;
-    // it's important to convert to [0, 1] while multiplication to uColor, not before, to preserve desired coloring functionality
-    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0);
+    // it's important to convert to [0, 1] while multiplying to uColor, not before, to preserve desired coloring functionality
+    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0) * uAlpha;
 }

--- a/src/visual/shaders/triShader.frag
+++ b/src/visual/shaders/triShader.frag
@@ -20,6 +20,7 @@ uniform float uFreq;
 uniform float uPhase;
 uniform float uPeriod;
 uniform vec3 uColor;
+uniform float uAlpha;
 
 void main() {
     vec2 uv = vUvs;
@@ -27,5 +28,5 @@ void main() {
     // converting first to [-1, 1] space to get the proper color functionality
     // then back to [0, 1]
     s = (2. * abs(s / uPeriod - floor(s / uPeriod + .5))) * 2. - 1.;
-    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0);
+    shaderOut = vec4(vec3(s) * uColor * .5 + .5, 1.0) * uAlpha;
 }


### PR DESCRIPTION
Image based gratings are now also work using a custom shader, which allows to do whatever necessary directly, through the fragment shader code rather than PIXI's tools.
- Added coloring support for image based Gratings
- Added proper support for for alpha channel, so `opacity` field now works as expected
- Texture coordinates for some Grating functions changed, so that the final image can match their PsychoPy counterparts