### PR TITLE
manual derivatives calculation for radial stim;

### DIFF
--- a/src/visual/GratingStim.js
+++ b/src/visual/GratingStim.js
@@ -2,7 +2,7 @@
  * Grating Stimulus.
  *
  * @author Nikita Agafonov
- * @version 2021.2.3
+ * @version 2022.3.0
  * @copyright (c) 2017-2020 Ilixa Ltd. (http://ilixa.com) (c) 2020-2022 Open Science Tools Ltd. (https://opensciencetools.org)
  * @license Distributed under the terms of the MIT License
  */
@@ -380,6 +380,8 @@ export class GratingStim extends VisualStim
 			shader: radialStimWGL1,
 			uniforms: {
 				uFreq: 20.0,
+				uStep: .0017,
+				uDX: 1.,
 				uPhase: 0.0,
 				uColor: [1., 1., 1.],
 				uAlpha: 1.0

--- a/src/visual/shaders/wgl1/radialShader.frag
+++ b/src/visual/shaders/wgl1/radialShader.frag
@@ -7,7 +7,6 @@
  * @description Creates 2d radial grating image. Based on https://www.shadertoy.com/view/wtjGzt
  * @usedby GratingStim.js
  */
-
 precision mediump float;
 
 varying vec2 vUvs;
@@ -16,20 +15,27 @@ uniform float uFreq;
 uniform float uPhase;
 uniform vec3 uColor;
 uniform float uAlpha;
+uniform float uStep;
+uniform float uDX;
 
 #define M_PI 3.14159265358979
 #define PI2 2.* M_PI
 
-float aastep(float x) {     // --- antialiased step(.5)
-    float w = fwidth(x);    // pixel width. NB: x must not be discontinuous or factor discont out
+float aastep(float x, float w) {     // --- antialiased step(.5)
     return smoothstep(.7,-.7,(abs(fract(x-.25)-.5)-.25)/w); // just use (offseted) smooth squares
 }
 
 void main() {
     vec2 uv = vUvs * 2. - 1.;
+    float v = uFreq * atan(uv.y, uv.x) / 6.28;
+    // WGL1 has dFdx, dFdy and fwidth() defined as part of OES_standard_derivatives extension.
+    // BUT using this extension fails due to how currently used version of PIXI goes about shader program compilation.
+    // Calculating derivatives manually instead.
+    float dF_dx = (uFreq * (atan(uv.y, uv.x + uStep) - atan(uv.y, uv.x - uStep)) / 6.28) / uDX;
+    float dF_dy = (uFreq * (atan(uv.y + uStep, uv.x) - atan(uv.y - uStep, uv.x)) / 6.28) / uDX;
+    float w = abs(dF_dx) + abs(dF_dy);
     // converting first to [-1, 1] space to get the proper color functionality
     // then back to [0, 1]
-    float v = uFreq * atan(uv.y, uv.x) / 6.28;
-    float s = aastep(v) * 2. - 1.;
+    float s = aastep(v, w) * 2. - 1.;
     gl_FragColor = vec4(vec3(s) * uColor * .5 + .5, 1.0) * uAlpha;
 }


### PR DESCRIPTION
Function used in antialiasing of original shader called `fwidth` which defined as sum of the absolute value of derivatives in x and y:
https://registry.khronos.org/OpenGL-Refpages/gl4/html/fwidth.xhtml

In wgl1 however this function is part of OES_standard_derivatives extension:
https://developer.mozilla.org/en-US/docs/Web/API/OES_standard_derivatives

BUT the PIXI version that we're currently using has weird way of going about compiling shader programs, specifically - it uses a separate "test" gl context, which has no clue about applied extensions. Because of that compilation of the shader code fails and no `fwidth` for us to play with.

In order to circumvent this I calculate derivatives manually and then add their absolutes together so that it all could work in default wgl1 context without extensions.