### PR TITLE
xlsx upgrade due to a string parsing bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "pixi.js-legacy": "^6.0.4",
     "seedrandom": "^3.0.5",
     "tone": "^14.7.77",
-    "xlsx": "^0.17.0"
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "csslint": "^1.0.5",


### PR DESCRIPTION
Upgrade due to discovered bug in which strings with partial month name in it treated as date. For instance `'nov_image'` get's converted to `{t: 'n', v: 37196, w: '11/1/01'}` instead of `{t: 's', v: 'nov_image'}`.