### PR TITLE
ENH Survey: better management of vendor libraries

### DIFF
--- a/src/core/PsychoJS.js
+++ b/src/core/PsychoJS.js
@@ -789,10 +789,11 @@ export class PsychoJS
 
 		const self = this;
 		window.onerror = function(message, source, lineno, colno, error)
-		{
+		{console.log('@@@', message)
 			// check for ResizeObserver loop limit exceeded error:
 			// ref: https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
-			if (message === "ResizeObserver loop limit exceeded")
+			if (message === "ResizeObserver loop limit exceeded" ||
+				message === "ResizeObserver loop completed with undelivered notifications.")
 			{
 				console.warn(message);
 				return true;

--- a/src/core/ServerManager.js
+++ b/src/core/ServerManager.js
@@ -535,6 +535,37 @@ export class ServerManager extends PsychObject
 								download: true
 							};
 						}
+
+						// deal with survey libraries:
+						if ("surveyLibrary" in resource)
+						{
+							// add the SurveyJS and PsychoJS Survey .js and .css resources:
+							resources[r] = {
+								name: "jquery-3.6.0.min.js",
+								path: "./lib/vendors/jquery-3.6.0.min.js",
+								download: true
+							};
+							resources.push({
+								name: "survey.jquery-1.9.50.min.js",
+								path: "./lib/vendors/survey.jquery-1.9.50.min.js",
+								download: true
+							});
+							resources.push({
+								name: "survey.defaultV2-1.9.50.min.css",
+								path: "./lib/vendors/survey.defaultV2-1.9.50.min.css",
+								download: true
+							});
+							resources.push({
+								name: "survey.widgets.css",
+								path: "./lib/vendors/survey.widgets.css",
+								download: true
+							});
+							resources.push({
+								name: "survey.grey_style.css",
+								path: "./lib/vendors/survey.grey_style.css",
+								download: true
+							});
+						}
 					}
 
 					for (let { name, path, download } of resources)

--- a/src/util/Clock.js
+++ b/src/util/Clock.js
@@ -58,13 +58,12 @@ export class MonotonicClock
 	 * <p>Note: This is just a convenience wrapper around `Intl.DateTimeFormat()`.</p>
 	 *
 	 * @param {string|array.string} locales - A string with a BCP 47 language tag, or an array of such strings.
-	 * @param {object} options - An object with detailed date and time styling information.
+	 * @param {object} [options] - An object with detailed date and time styling information.
 	 * @return {string} The current timestamp in the chosen format.
 	 */
-	static getDate(locales = "en-CA", optionsMaybe)
+	static getDate(locales = "en-CA", options)
 	{
-		const date = new Date();
-		const options = Object.assign({
+		const dataTimeOptions = Object.assign({
 			hour12: false,
 			year: "numeric",
 			month: "2-digit",
@@ -73,10 +72,10 @@ export class MonotonicClock
 			minute: "numeric",
 			second: "numeric",
 			fractionalSecondDigits: 3,
-		}, optionsMaybe);
+		}, options);
+		const dateTimeFormat = new Intl.DateTimeFormat(locales, dataTimeOptions);
 
-		const dateTimeFormat = new Intl.DateTimeFormat(locales, options);
-
+		const date = new Date();
 		return dateTimeFormat.format(date);
 	}
 

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -1434,11 +1434,6 @@ export function loadCss(cssId, cssPath)
 		link.media = "all";
 		head.appendChild(link);
 	}
-
-	/* document.getElementsByTagName("head")[0].insertAdjacentHTML(
-		"beforeend",
-		`<link rel="stylesheet" href="${cssPath}" />`
-	); */
 }
 
 /**

--- a/src/visual/Survey.js
+++ b/src/visual/Survey.js
@@ -52,6 +52,12 @@ export class Survey extends VisualStim
 	{
 		super({ name, win, units, ori, depth, pos, size, autoDraw, autoLog });
 
+		// default size:
+		if (typeof size === "undefined")
+		{
+			this.size = (this.unit === "norm") ? [2.0, 2.0] : [1.0, 1.0];
+		}
+
 		// init SurveyJS
 		this._initSurveyJS();
 
@@ -392,7 +398,6 @@ export class Survey extends VisualStim
 			if (typeof this._surveyModel !== "undefined")
 			{
 				this._startSurvey(surveyId, this._surveyModel);
-				// jQuery(`#${surveyId}`).Survey({model: this._surveyModel});
 			}
 		}
 


### PR DESCRIPTION
It is now possible to add `{'surveyLibrary': true}` as a resource to ensure that the adequate Survey libraries are loaded at the start of the experiment.

`psychoJS.start({ [...] 
  resources: [
    {'surveyLibrary': true}
  ]});`
