### PR TITLE
NF: Adding field seperator selection in output

### DIFF
--- a/src/data/ExperimentHandler.js
+++ b/src/data/ExperimentHandler.js
@@ -81,9 +81,9 @@ export class ExperimentHandler extends PsychObject
 		this._datetime = (typeof extraInfo.date !== "undefined")
 			? extraInfo.date
 			: MonotonicClock.getDateStr();
-		this._field_seperator = (typeof extraInfo.field_seperator === "string" || extraInfo.field_seperator.length === 1 || extraInfo.field_seperator !== '\n')
-			? extraInfo.field_seperator
-		  : ',';
+		this._field_separator = (typeof extraInfo.field_separator === "string" || extraInfo.field_separator.length === 1 || extraInfo.field_separator !== '\n')
+			? extraInfo.field_separator
+  		: ',';
 
 		this._addAttribute(
 			"dataFileName",
@@ -294,7 +294,7 @@ export class ExperimentHandler extends PsychObject
 			// TODO only save the given attributes
 			const worksheet = XLSX.utils.json_to_sheet(data);
 			// prepend BOM
-			const csv = "\ufeff" + XLSX.utils.sheet_to_csv(worksheet, FS=this._field_seperator);
+			const csv = "\ufeff" + XLSX.utils.sheet_to_csv(worksheet, FS=this._field_separator);
 
 			// upload data to the pavlovia server or offer them for download:
 			const filenameWithoutPath = this._dataFileName.split(/[\\/]/).pop();

--- a/src/data/ExperimentHandler.js
+++ b/src/data/ExperimentHandler.js
@@ -81,6 +81,9 @@ export class ExperimentHandler extends PsychObject
 		this._datetime = (typeof extraInfo.date !== "undefined")
 			? extraInfo.date
 			: MonotonicClock.getDateStr();
+		this._field_seperator = (typeof extraInfo.field_seperator === "string" || extraInfo.field_seperator.length === 1 || extraInfo.field_seperator !== '\n')
+			? extraInfo.field_seperator
+		  : ',';
 
 		this._addAttribute(
 			"dataFileName",
@@ -291,7 +294,7 @@ export class ExperimentHandler extends PsychObject
 			// TODO only save the given attributes
 			const worksheet = XLSX.utils.json_to_sheet(data);
 			// prepend BOM
-			const csv = "\ufeff" + XLSX.utils.sheet_to_csv(worksheet);
+			const csv = "\ufeff" + XLSX.utils.sheet_to_csv(worksheet, FS=this._field_seperator);
 
 			// upload data to the pavlovia server or offer them for download:
 			const filenameWithoutPath = this._dataFileName.split(/[\\/]/).pop();

--- a/src/data/ExperimentHandler.js
+++ b/src/data/ExperimentHandler.js
@@ -294,7 +294,7 @@ export class ExperimentHandler extends PsychObject
 			// TODO only save the given attributes
 			const worksheet = XLSX.utils.json_to_sheet(data);
 			// prepend BOM
-			const csv = "\ufeff" + XLSX.utils.sheet_to_csv(worksheet, FS=this._field_separator);
+			const csv = "\ufeff" + XLSX.utils.sheet_to_csv(worksheet, {FS: this._field_separator});
 
 			// upload data to the pavlovia server or offer them for download:
 			const filenameWithoutPath = this._dataFileName.split(/[\\/]/).pop();


### PR DESCRIPTION
Following [this](https://github.com/psychopy/psychopy/issues/5141) feature request, this pull request will allow passing the data delimiter selected on PsychoPy, when converting the experiment to PsychoJS. 

Note that the changes are not implemented yet on the PsychoPy end, and `psychoJS.ExperimentHandler._field_separator` is an undefined property. Thus the expected behavior is that the default (',') field separator will be selected. 