### PR TITLE
Alias all numpy.random functions which PsychoPy imports

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -960,12 +960,31 @@ export function turnSquareBracketsIntoArrays(input, max = 1)
  * @param {number} max - one above the largest integer to be drawn
  * @returns {number} a random integer in the requested range (signed)
  */
-export function randint(min = 0, max)
+export function randint(min, max = null, size = 1)
 {
+	if (!Number.isInteger(size) | size < 1) {
+		// raise error if given an invalid size
+		throw {
+			origin: "util.random",
+			context: "when generating a random float",
+			error: "size must be a positive integer above 0",
+		};
+	}
+	
+	if (size > 1) {
+		// if size > 1, call function multiple times with size = 1 and return an array
+		let values = []
+		for (let i = 0; i < size; i++) {
+			values.push(randint(min, max, 1));
+		}
+		return values
+	}
+
 	let lo = min;
 	let hi = max;
 
-	if (typeof max === "undefined")
+	// if no max given, go from 0 to min
+	if (max === null)
 	{
 		hi = lo;
 		lo = 0;

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -468,9 +468,8 @@ export function randchoice(a, size = 1, replace = true, p = null, randomNumberGe
 			// if replace is false, remove value from copy of array
 			if (!replace) {
 				let j = tempArray.indexOf(val)
-				tempArray.pop(tempArray[j])
-				weights.pop(weights[j])
-
+				tempArray.splice(j, 1)
+				weights.splice(j, 1)
 			}
 		}
 		return values

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -427,11 +427,30 @@ export function shuffle(array, randomNumberGenerator = undefined)
  * Pick a random value from an array, uses `util.shuffle` to shuffle the array and returns the last value.
  *
  * @param {Object[]} array - the input 1-D array
+ * @param {number} [size = 1] - number of values to return
  * @param {Function} [randomNumberGenerator = undefined] - A function used to generated random numbers in the interal [0, 1). Defaults to Math.random
  * @return {Object[]} a chosen value from the array
  */
-export function randchoice(array, randomNumberGenerator = undefined)
+export function randchoice(array, size = 1, randomNumberGenerator = undefined)
 {
+	if (!Number.isInteger(size) | size < 1) {
+		// raise error if given an invalid size
+		throw {
+			origin: "util.random",
+			context: "when generating a random float",
+			error: "size must be a positive integer above 0",
+		};
+	}
+	
+	if (size > 1) {
+		// if size > 1, call function multiple times with size = 1 and return an array
+		let values = []
+		for (let i = 0; i < size; i++) {
+			values.push(randchoice(array, 1, randomNumberGenerator));
+		}
+		return values
+	}
+
 	if (randomNumberGenerator === undefined)
 	{
 		randomNumberGenerator = Math.random;

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -331,11 +331,61 @@ export function random(size = 1) {
 		// if size is >1, return an array
 		let values = []
 		for (let i = 0; i < size; i++) {
-			values.push(Math.random());
+			values.push(random(1));
 		}
 		return values
 	}
 }
+
+/**
+ * Generates random integers a-la NumPy's in the "half-open" interval [min, max). In other words, from min inclusive to max exclusive. When max is undefined, as is the case by default, results are chosen from [0, min). An error is thrown if max is less than min.
+ *
+ * @param {number} [min = 0] - lowest integer to be drawn, or highest plus one if max is undefined (default)
+ * @param {number} max - one above the largest integer to be drawn
+ * @returns {number} a random integer in the requested range (signed)
+ */
+export function randint(min, max = null, size = 1)
+{
+	if (!Number.isInteger(size) | size < 1) {
+		// raise error if given an invalid size
+		throw {
+			origin: "util.random",
+			context: "when generating a random float",
+			error: "size must be a positive integer above 0",
+		};
+	}
+	
+	if (size > 1) {
+		// if size > 1, call function multiple times with size = 1 and return an array
+		let values = []
+		for (let i = 0; i < size; i++) {
+			values.push(randint(min, max, 1));
+		}
+		return values
+	}
+
+	let lo = min;
+	let hi = max;
+
+	// if no max given, go from 0 to min
+	if (max === null)
+	{
+		hi = lo;
+		lo = 0;
+	}
+
+	if (hi < lo)
+	{
+		throw {
+			origin: "util.randint",
+			context: "when generating a random integer",
+			error: "min should be <= max",
+		};
+	}
+
+	return Math.floor(Math.random() * (hi - lo)) + lo;
+}
+
 
 /**
  * Shuffle an array in place using the Fisher-Yastes's modern algorithm
@@ -951,55 +1001,6 @@ export function turnSquareBracketsIntoArrays(input, max = 1)
 	}
 
 	return matches;
-}
-
-/**
- * Generates random integers a-la NumPy's in the "half-open" interval [min, max). In other words, from min inclusive to max exclusive. When max is undefined, as is the case by default, results are chosen from [0, min). An error is thrown if max is less than min.
- *
- * @param {number} [min = 0] - lowest integer to be drawn, or highest plus one if max is undefined (default)
- * @param {number} max - one above the largest integer to be drawn
- * @returns {number} a random integer in the requested range (signed)
- */
-export function randint(min, max = null, size = 1)
-{
-	if (!Number.isInteger(size) | size < 1) {
-		// raise error if given an invalid size
-		throw {
-			origin: "util.random",
-			context: "when generating a random float",
-			error: "size must be a positive integer above 0",
-		};
-	}
-	
-	if (size > 1) {
-		// if size > 1, call function multiple times with size = 1 and return an array
-		let values = []
-		for (let i = 0; i < size; i++) {
-			values.push(randint(min, max, 1));
-		}
-		return values
-	}
-
-	let lo = min;
-	let hi = max;
-
-	// if no max given, go from 0 to min
-	if (max === null)
-	{
-		hi = lo;
-		lo = 0;
-	}
-
-	if (hi < lo)
-	{
-		throw {
-			origin: "util.randint",
-			context: "when generating a random integer",
-			error: "min should be <= max",
-		};
-	}
-
-	return Math.floor(Math.random() * (hi - lo)) + lo;
 }
 
 /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -323,18 +323,17 @@ export function random(size = 1) {
 			error: "size must be a positive integer above 0",
 		};
 	}
-	
-	if (size === 1) {
-		// if size is 1, return a single value
-		return Math.random();
-	} else {
-		// if size is >1, return an array
+
+	if (size > 1) {
+		// if size > 1, call function multiple times with size = 1 and return an array
 		let values = []
 		for (let i = 0; i < size; i++) {
 			values.push(random(1));
 		}
 		return values
 	}
+
+	return Math.random();
 }
 
 /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -341,6 +341,7 @@ export function random(size = 1) {
  *
  * @param {number} [min = 0] - lowest integer to be drawn, or highest plus one if max is undefined (default)
  * @param {number} max - one above the largest integer to be drawn
+ * @param {number} [size = 1] - number of values to return
  * @returns {number} a random integer in the requested range (signed)
  */
 export function randint(min, max = null, size = 1)

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -308,6 +308,36 @@ export function IsPointInsidePolygon(point, vertices)
 }
 
 /**
+ * Return random floats a-la NumPy's in the half-open interval [0.0, 1.0). In other words, from 0 inclusive to 1 exclusive.
+ * 
+ * @param {number} [size = 1] - number of values to return
+ * @returns {number} single random float from uniform distribution, if size === 1
+ * @returns {Object[]} array of uniformly distributed random floats, if size > 1
+ */
+export function random(size = 1) {
+	if (!Number.isInteger(size) | size < 1) {
+		// raise error if given an invalid size
+		throw {
+			origin: "util.random",
+			context: "when generating a random float",
+			error: "size must be a positive integer above 0",
+		};
+	}
+	
+	if (size === 1) {
+		// if size is 1, return a single value
+		return Math.random();
+	} else {
+		// if size is >1, return an array
+		let values = []
+		for (let i = 0; i < size; i++) {
+			values.push(Math.random());
+		}
+		return values
+	}
+}
+
+/**
  * Shuffle an array in place using the Fisher-Yastes's modern algorithm
  * <p>See details here: https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm</p>
  *

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -431,22 +431,37 @@ export function shuffle(array, randomNumberGenerator = undefined)
  * @param {Function} [randomNumberGenerator = undefined] - A function used to generated random numbers in the interal [0, 1). Defaults to Math.random
  * @return {Object[]} a chosen value from the array
  */
-export function randchoice(array, size = 1, randomNumberGenerator = undefined)
+export function randchoice(array, size = 1, replace = true, randomNumberGenerator = undefined)
 {
 	if (!Number.isInteger(size) | size < 1) {
 		// raise error if given an invalid size
 		throw {
 			origin: "util.random",
-			context: "when generating a random float",
+			context: "when choosing a random value from array",
 			error: "size must be a positive integer above 0",
+		};
+	}
+	if (!replace & size > array.length) {
+		// if replace is fase, then size can't exceed size of array as each value can only be used once
+		throw {
+			origin: "util.random",
+			context: "when choosing a random value from array",
+			error: "size cannot exceed length of array when replace is false",
 		};
 	}
 	
 	if (size > 1) {
 		// if size > 1, call function multiple times with size = 1 and return an array
 		let values = []
+		let tempArray = array
 		for (let i = 0; i < size; i++) {
-			values.push(randchoice(array, 1, randomNumberGenerator));
+			// add value taken from copy of array
+			let val = randchoice(tempArray, 1, replace, randomNumberGenerator)
+			values.push(val)
+			// if replace is false, remove value from copy of array
+			if (!replace) {
+				tempArray.pop(val)
+			}
 		}
 		return values
 	}

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -350,7 +350,7 @@ export function randint(min, max = null, size = 1)
 		// raise error if given an invalid size
 		throw {
 			origin: "util.random",
-			context: "when generating a random float",
+			context: "when generating a random integer",
 			error: "size must be a positive integer above 0",
 		};
 	}

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -434,6 +434,12 @@ export function shuffle(array, randomNumberGenerator = undefined)
  */
 export function randchoice(a, size = 1, replace = true, p = null, randomNumberGenerator = null)
 {
+	let weights = p
+	if (weights === null) {
+		// if no weights given, use uniform
+		weights = Array.from({length: a.length}, () => 1/a.length)
+	}
+
 	if (!Number.isInteger(size) | size < 1) {
 		// raise error if given an invalid size
 		throw {
@@ -461,7 +467,10 @@ export function randchoice(a, size = 1, replace = true, p = null, randomNumberGe
 			values.push(val)
 			// if replace is false, remove value from copy of array
 			if (!replace) {
-				tempArray.pop(val)
+				let j = tempArray.indexOf(val)
+				tempArray.pop(tempArray[j])
+				weights.pop(weights[j])
+
 			}
 		}
 		return values
@@ -471,12 +480,6 @@ export function randchoice(a, size = 1, replace = true, p = null, randomNumberGe
 	{
 		// use Math.random if no generator given
 		randomNumberGenerator = Math.random;
-	}
-
-	let weights = p
-	if (weights === null) {
-		// if no weights given, use uniform
-		weights = Array.from({length: a.length}, () => 1/a.length)
 	}
 
 	// normalize and accumulate weights

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -386,6 +386,20 @@ export function randint(min, max = null, size = 1)
 	return Math.floor(Math.random() * (hi - lo)) + lo;
 }
 
+/**
+ * Generate normally distributed random values.
+ * 
+ * Not yet implemented in PsychoJS.
+ * 
+ */
+export function normal(loc = 0.0, scale = 1.0, size = null)
+{
+	throw {
+		origin: "util.normal",
+		context: "when generating a random normally distributed value",
+		error: "function `normal` is not yet implemented in PsychoJS"
+	}
+}
 
 /**
  * Shuffle an array in place using the Fisher-Yastes's modern algorithm


### PR DESCRIPTION
I noticed some discrepancies between the random functions in utils and their numpy counterparts. The functions themselves seem simple enough that my rudimentary JS should be adequate so I had a go at bringing about parity. Apart from numpy.random.normal - for which I've just added an exception to be a bit more informative.

I've done some testing just from copying the functions to a script and running it in an HTML file, but please do run it through the proper test suite! My tests were:
```
console.log([random(), random(), random(), random(), random(),])
console.log(random(5))
console.log([randint(4), randint(4), randint(4), randint(4), randint(4),])
console.log(randint(5))
console.log(randint(2, 4, 5))
console.log(shuffle([1, 2, 3]))
console.log(shuffle([1, 2, 3]))
console.log(shuffle([1, 2, 3]))
console.log(randchoice([1, 2, 3], 3, false, [0.5, 0.1, 0.1]))
console.log(randchoice([1, 2, 3], 3, false, [0.5, 0.1, 0.1]))
console.log(randchoice([1, 2, 3], 3, false, [0.5, 0.1, 0.1]))
console.log(randchoice([1, 2, 3], 5, true, [0.5, 0.1, 0.1]))
```
which seemed to behave as expected