### PR TITLE
ENH: If exit message is specified, don't prepend "Thank you for your patience"

### DIFF
--- a/src/core/PsychoJS.js
+++ b/src/core/PsychoJS.js
@@ -602,8 +602,8 @@ export class PsychoJS
 
 			if (showOK)
 			{
-				let text = "Thank you for your patience.";
-				text += (typeof message !== "undefined") ? message : "Goodbye!";
+				let text = "";
+				text += (typeof message !== "undefined") ? message : "Thank you for your patience. Goodbye!";
 				this._gui.dialog({
 					message: text,
 					onOK: onTerminate


### PR DESCRIPTION
Accompanies [psychopy#6258](https://github.com/psychopy/psychopy/pull/6258) - we can supply an end message from Builder, but currently it will always follow "Thank you for your patience" rather than replacing it. This change means that users can fully customise the message.