### PR TITLE
BF: Import Clock utils in core for parity with PsychoPy

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -8,3 +8,4 @@ export * from "./PsychoJS.js";
 export * from "./ServerManager.js";
 export * from "./Window.js";
 export * from "./WindowMixin.js";
+export * from "../util/Clock.js";


### PR DESCRIPTION
Currently, if you do the following in a Code Component:
```
tRemaining = core.CountdownTimer(5)
```
you'll get an attribute error because `PsychoJS.core` doesn't have a `CountdownTimer` - but it does exist, it's just in `PsychoJS.util`. 

We could catch this in the translation in PsychoPy and sub in `util`, but for something as simple as just importing a class in a second location it seems reasonable to change the JS end to not need this substitution. Plus it means that users manually coding (with a Code Component set to "both") can refer to `core.CountdownTimer`, which they might if they're used to PsychoPy.