### PR TITLE
BF: Handle when `Sound.setSound` is given a value rather than a Sound object

### DIFF
--- a/src/sound/Sound.js
+++ b/src/sound/Sound.js
@@ -156,11 +156,10 @@ export class Sound extends PsychObject
 	{
 		if (!(sound instanceof Sound))
 		{
-			throw {
-				origin: "Sound.setSound",
-				context: "when setting the sound",
-				error: "the argument should be an instance of the Sound class.",
-			};
+			// if given something other than a Sound, do setValue instead
+			this.setValue(sound, log);
+			
+			return this;
 		}
 
 		this._setAttribute("value", sound.value, log);


### PR DESCRIPTION
In Builder, the parameter defining the sound to play is called `sound`, so when it's set dynamically (each repeat, in resource manager, in a static component, etc.) the method called is `setSound`. In PsychoJS, this fails because `setSound` expects another Sound object, not a value.

I've handled this on the PsychoPy end by manually replacing `setSound` with `setValue`, but this doesn't cover e.g. setting via a Static Component, as that uses its own code. 

This PR means that, if given something other than a Sound object, it will be as if the same value was passed to setValue.