### PR TITLE
BF: Prevent exception on ImageStim.setImage(undefined)

### DIFF
--- a/src/visual/ImageStim.js
+++ b/src/visual/ImageStim.js
@@ -194,7 +194,7 @@ export class ImageStim extends util.mix(VisualStim).with(ColorMixin)
 			}
 
 			const existingImage = this.getImage();
-			const hasChanged = existingImage ? existingImage.src !== image.src : true;
+			const hasChanged = existingImage && image ? existingImage.src !== image.src : existingImage || image;
 
 			this._setAttribute("image", image, log);
 


### PR DESCRIPTION
If the image of an `ImageStim` is based off a column in a data file, and an entry in that column is blank because there is not supposed to be an image, then the experiment crashes.

At present, `ImageStim` can handle having an `undefined` image (a) initially, and (b) when `setImage(undefined)` is called while the image is already `undefined`. In the second case, it handles the `onChanged` signal gracefully, because it checks whether `existingImage` is valid before accessing `existingImage.src` or `image.src`. However, if `existingImage` is valid but `image` is not (because you're trying to clear the image by intentionally setting it to `undefined`), then the check is insufficient and we get an unhandled exception on `image.src`.

This also changes the `hasChanged` logic to be `false` if both `existingImage` and `image` are `undefined` - but I think whether that should be the case is a design consideration. I don't have any sense of what `_onChange` is needed for, so I don't know which functionality is more appropriate. Feel free to revert to just `: true;` if it doesn't make sense.